### PR TITLE
[ZVXY-12] fix: 임시로 Spring Security 인증 비활성화

### DIFF
--- a/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/health", "/h2-console/**").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
-                .anyRequest().authenticated()
+                // TODO: JWT 구현 완료 후 .authenticated()로 변경
+                .anyRequest().permitAll()  // 임시로 모든 요청 허용
             )
             .headers(headers -> headers
                 .frameOptions(frameOptions -> frameOptions.sameOrigin())


### PR DESCRIPTION
[ZVXY-12] 
- JWT 구현 전까지 임시로 모든 요청 허용
- .anyRequest().authenticated() → .anyRequest().permitAll()

[ZVXY-12]: https://yonggeun.atlassian.net/browse/ZVXY-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ