### PR TITLE
[ZVXY-21] fix(ci): 조직 레포에서 sync 워크플로우 실행 방지

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # fork된 레포에서만 실행 (조직 레포에서는 건너뜀)
+    if: github.repository != 'WageManager/WageManager-backend'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
- fork된 개인 레포에서만 실행되도록 조건 추가
- 조직 레포에서는 워크플로우 skip으로 실패 알람 방지