### PR TITLE
[ZVXY-26] refactor: 개발용 임시 로그인 엔드포인트 제거

### DIFF
--- a/src/main/java/com/example/wagemanager/api/auth/AuthController.java
+++ b/src/main/java/com/example/wagemanager/api/auth/AuthController.java
@@ -55,28 +55,4 @@ public class AuthController {
         return ApiResponse.success(AuthDto.LogoutResponse.success());
     }
 
-    /**
-     * 개발용 임시 로그인 API
-     * userId로 로그인하여 JWT 토큰 발급
-     * TODO: 추후 카카오 OAuth 로그인으로 대체 예정
-     */
-    @PostMapping("/dev/login")
-    public ApiResponse<AuthDto.LoginResponse> devLogin(@RequestBody AuthDto.DevLoginRequest request) {
-        // 사용자 조회
-        User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId: " + request.getUserId()));
-
-        // JWT 토큰 생성
-        String token = jwtTokenProvider.generateToken(user.getId());
-
-        // 응답 DTO 생성
-        AuthDto.LoginResponse response = AuthDto.LoginResponse.builder()
-                .accessToken(token)
-                .userId(user.getId())
-                .name(user.getName())
-                .userType(user.getUserType().name())
-                .build();
-
-        return ApiResponse.success(response);
-    }
 }

--- a/src/main/java/com/example/wagemanager/api/auth/dto/AuthDto.java
+++ b/src/main/java/com/example/wagemanager/api/auth/dto/AuthDto.java
@@ -12,17 +12,6 @@ import lombok.NoArgsConstructor;
 public class AuthDto {
 
     /**
-     * 개발용 임시 로그인 요청 DTO
-     */
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class DevLoginRequest {
-        private Long userId;
-    }
-
-    /**
      * 카카오 로그인 요청 DTO
      */
     @Getter

--- a/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/health", "/h2-console/**").permitAll()
-                .requestMatchers("/api/auth/dev/**", "/api/auth/kakao/login", "/api/auth/kakao/register").permitAll()
+                .requestMatchers("/api/auth/kakao/login", "/api/auth/kakao/register").permitAll()
                 .requestMatchers("/api/users/register").permitAll()
                 .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
카카오 OAuth 로그인 구현 완료에 따라 dev/login 엔드포인트 및 관련 코드 제거:

- AuthController에서 devLogin() 메서드 삭제
- AuthDto에서 DevLoginRequest DTO 클래스 삭제
- SecurityConfig에서 /api/auth/dev/** 허용 규칙 제거