### PR TITLE
fix: Swagger UI에서 잘못된 Response DTO 표시 문제 해결

### DIFF
--- a/src/main/java/com/example/wagemanager/api/auth/dto/AuthDto.java
+++ b/src/main/java/com/example/wagemanager/api/auth/dto/AuthDto.java
@@ -1,5 +1,6 @@
 package com.example.wagemanager.api.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class AuthDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Schema(name = "AuthKakaoLoginRequest")
     public static class KakaoLoginRequest {
 
         @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
@@ -31,6 +33,7 @@ public class AuthDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Schema(name = "AuthKakaoRegisterRequest")
     public static class KakaoRegisterRequest {
 
         @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
@@ -47,6 +50,7 @@ public class AuthDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Schema(name = "AuthLoginResponse")
     public static class LoginResponse {
         private String accessToken;
         private Long userId;
@@ -57,6 +61,7 @@ public class AuthDto {
     @Getter
     @AllArgsConstructor
     @Builder
+    @Schema(name = "AuthLogoutResponse")
     public static class LogoutResponse {
         private String message;
 

--- a/src/main/java/com/example/wagemanager/domain/contract/dto/ContractDto.java
+++ b/src/main/java/com/example/wagemanager/domain/contract/dto/ContractDto.java
@@ -1,6 +1,7 @@
 package com.example.wagemanager.domain.contract.dto;
 
 import com.example.wagemanager.domain.contract.entity.WorkerContract;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ public class ContractDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "ContractCreateRequest")
     public static class CreateRequest {
         @NotBlank(message = "근로자 코드는 필수입니다.")
         private String workerCode;
@@ -47,6 +49,7 @@ public class ContractDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "ContractUpdateRequest")
     public static class UpdateRequest {
         @DecimalMin(value = "10030.0", inclusive = true, message = "시급은 10,030 이상이어야 합니다.")
         private BigDecimal hourlyWage;
@@ -68,6 +71,7 @@ public class ContractDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "ContractResponse")
     public static class Response {
         private Long id;
         private Long workplaceId;
@@ -108,6 +112,7 @@ public class ContractDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "ContractListResponse")
     public static class ListResponse {
         private Long id;
         private String workerName;

--- a/src/main/java/com/example/wagemanager/domain/correction/dto/CorrectionRequestDto.java
+++ b/src/main/java/com/example/wagemanager/domain/correction/dto/CorrectionRequestDto.java
@@ -2,6 +2,7 @@ package com.example.wagemanager.domain.correction.dto;
 
 import com.example.wagemanager.domain.correction.entity.CorrectionRequest;
 import com.example.wagemanager.domain.correction.enums.CorrectionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class CorrectionRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "CorrectionRequestCreateRequest")
     public static class CreateRequest {
         @NotNull
         private Long workRecordId;
@@ -35,6 +37,7 @@ public class CorrectionRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "CorrectionRequestReviewRequest")
     public static class ReviewRequest {
         private String reviewComment;
     }
@@ -43,6 +46,7 @@ public class CorrectionRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "CorrectionRequestResponse")
     public static class Response {
         private Long id;
         private Long workRecordId;
@@ -96,6 +100,7 @@ public class CorrectionRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "CorrectionRequestListResponse")
     public static class ListResponse {
         private Long id;
         private Long workRecordId;
@@ -136,6 +141,7 @@ public class CorrectionRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "CorrectionRequestRequesterInfo")
     public static class RequesterInfo {
         private Long id;
         private String name;
@@ -145,6 +151,7 @@ public class CorrectionRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "CorrectionRequestReviewerInfo")
     public static class ReviewerInfo {
         private Long id;
         private String name;

--- a/src/main/java/com/example/wagemanager/domain/payment/dto/PaymentDto.java
+++ b/src/main/java/com/example/wagemanager/domain/payment/dto/PaymentDto.java
@@ -2,6 +2,7 @@ package com.example.wagemanager.domain.payment.dto;
 
 import com.example.wagemanager.domain.payment.entity.Payment;
 import com.example.wagemanager.domain.payment.enums.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public class PaymentDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "PaymentPaymentRequest")
     public static class PaymentRequest {
         @NotNull(message = "급여 ID는 필수입니다.")
         private Long salaryId;
@@ -26,6 +28,7 @@ public class PaymentDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "PaymentResponse")
     public static class Response {
         private Long id;
         private Long salaryId;
@@ -66,6 +69,7 @@ public class PaymentDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "PaymentListResponse")
     public static class ListResponse {
         private Long id;
         private Long salaryId;

--- a/src/main/java/com/example/wagemanager/domain/salary/dto/SalaryDto.java
+++ b/src/main/java/com/example/wagemanager/domain/salary/dto/SalaryDto.java
@@ -1,6 +1,7 @@
 package com.example.wagemanager.domain.salary.dto;
 
 import com.example.wagemanager.domain.salary.entity.Salary;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class SalaryDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "SalaryResponse")
     public static class Response {
         private Long id;
         private Long contractId;
@@ -66,6 +68,7 @@ public class SalaryDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "SalaryListResponse")
     public static class ListResponse {
         private Long id;
         private String workerName;

--- a/src/main/java/com/example/wagemanager/domain/user/dto/UserDto.java
+++ b/src/main/java/com/example/wagemanager/domain/user/dto/UserDto.java
@@ -2,6 +2,7 @@ package com.example.wagemanager.domain.user.dto;
 
 import com.example.wagemanager.domain.user.entity.User;
 import com.example.wagemanager.domain.user.enums.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class UserDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserResponse")
     public static class Response {
         private Long id;
         private String kakaoId;
@@ -37,6 +39,7 @@ public class UserDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserUpdateRequest")
     public static class UpdateRequest {
         private String name;
         private String phone;
@@ -47,6 +50,7 @@ public class UserDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserRegisterRequest")
     public static class RegisterRequest {
         private String kakaoId;
         private String name;
@@ -59,6 +63,7 @@ public class UserDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserRegisterResponse")
     public static class RegisterResponse {
         private Long userId;
         private String name;

--- a/src/main/java/com/example/wagemanager/domain/worker/dto/WorkerDto.java
+++ b/src/main/java/com/example/wagemanager/domain/worker/dto/WorkerDto.java
@@ -1,6 +1,7 @@
 package com.example.wagemanager.domain.worker.dto;
 
 import com.example.wagemanager.domain.worker.entity.Worker;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class WorkerDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkerResponse")
     public static class Response {
         private Long id;
         private Long userId;
@@ -36,6 +38,7 @@ public class WorkerDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkerUpdateRequest")
     public static class UpdateRequest {
         // private String accountNumber;
         // private String bankName;

--- a/src/main/java/com/example/wagemanager/domain/workplace/dto/WorkplaceDto.java
+++ b/src/main/java/com/example/wagemanager/domain/workplace/dto/WorkplaceDto.java
@@ -1,6 +1,7 @@
 package com.example.wagemanager.domain.workplace.dto;
 
 import com.example.wagemanager.domain.workplace.entity.Workplace;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -17,6 +18,7 @@ public class WorkplaceDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkplaceCreateRequest")
     public static class CreateRequest {
         @NotBlank(message = "사업자 등록번호는 필수입니다.")
         @Pattern(regexp = "\\d{3}-\\d{2}-\\d{5}", message = "사업자 등록번호 형식이 올바르지 않습니다. (예: 123-45-67890)")
@@ -41,6 +43,7 @@ public class WorkplaceDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkplaceUpdateRequest")
     public static class UpdateRequest {
         private String businessName;
         private String name;
@@ -57,6 +60,7 @@ public class WorkplaceDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkplaceResponse")
     public static class Response {
         private Long id;
         private String businessNumber;
@@ -89,6 +93,7 @@ public class WorkplaceDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkplaceListResponse")
     public static class ListResponse {
         private Long id;
         private String businessName;

--- a/src/main/java/com/example/wagemanager/domain/workrecord/dto/WorkRecordDto.java
+++ b/src/main/java/com/example/wagemanager/domain/workrecord/dto/WorkRecordDto.java
@@ -2,6 +2,7 @@ package com.example.wagemanager.domain.workrecord.dto;
 
 import com.example.wagemanager.domain.workrecord.entity.WorkRecord;
 import com.example.wagemanager.domain.workrecord.enums.WorkRecordStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class WorkRecordDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkRecordResponse")
     public static class Response {
         private Long id;
         private Long contractId;
@@ -48,6 +50,7 @@ public class WorkRecordDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkRecordDetailedResponse")
     public static class DetailedResponse {
         private Long id;
         private Long contractId;
@@ -86,6 +89,7 @@ public class WorkRecordDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkRecordCalendarResponse")
     public static class CalendarResponse {
         private Long id;
         private Long contractId;
@@ -114,6 +118,7 @@ public class WorkRecordDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkRecordCreateRequest")
     public static class CreateRequest {
         @NotNull
         private Long contractId;
@@ -131,6 +136,7 @@ public class WorkRecordDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkRecordBatchCreateRequest")
     public static class BatchCreateRequest {
         @NotNull
         private Long contractId;
@@ -148,6 +154,7 @@ public class WorkRecordDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "WorkRecordUpdateRequest")
     public static class UpdateRequest {
         private LocalTime startTime;
         private LocalTime endTime;


### PR DESCRIPTION
모든 DTO 클래스에 @Schema 어노테이션 추가하여 Swagger가 올바른 스키마를 인식하도록 수정

- SpringDoc OpenAPI와 Lombok 호환성 문제로 인해 발생한 스키마 혼동 해결
- 모든 DTO 내부 static 클래스에 고유한 스키마 이름 지정
- 수정된 파일: AuthDto, ContractDto, CorrectionRequestDto, PaymentDto, SalaryDto, UserDto, WorkerDto, WorkplaceDto, WorkRecordDto