### PR TITLE
feat: Refresh Token 기능 구현

### DIFF
--- a/src/main/java/com/example/wagemanager/WagemanagerApplication.java
+++ b/src/main/java/com/example/wagemanager/WagemanagerApplication.java
@@ -2,8 +2,10 @@ package com.example.wagemanager;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class WagemanagerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/wagemanager/api/auth/AuthController.java
+++ b/src/main/java/com/example/wagemanager/api/auth/AuthController.java
@@ -4,12 +4,14 @@ import com.example.wagemanager.api.auth.dto.AuthDto;
 import com.example.wagemanager.common.dto.ApiResponse;
 import com.example.wagemanager.domain.auth.service.AuthService;
 import com.example.wagemanager.domain.user.entity.User;
-import com.example.wagemanager.domain.user.repository.UserRepository;
-import com.example.wagemanager.global.security.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,30 +22,104 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final UserRepository userRepository;
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpirationTime; // 밀리초 단위
 
     @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰을 검증하고 자체 JWT를 발급합니다.")
     @PostMapping("/kakao/login")
     public ApiResponse<AuthDto.LoginResponse> kakaoLogin(
-            @Valid @RequestBody AuthDto.KakaoLoginRequest request
-    ) {
-        return ApiResponse.success(authService.loginWithKakao(request.getKakaoAccessToken()));
+            @Valid @RequestBody AuthDto.KakaoLoginRequest request,
+            HttpServletResponse response) {
+        AuthService.LoginResult loginResult = authService.loginWithKakao(request.getKakaoAccessToken());
+
+        // Refresh Token을 HttpOnly Cookie로 설정
+        setRefreshTokenCookie(response, loginResult.getRefreshToken());
+
+        return ApiResponse.success(loginResult.getLoginResponse());
     }
 
     @Operation(summary = "카카오 회원가입", description = "카카오 프로필 정보를 기반으로 사용자를 등록하고 JWT를 발급합니다.")
     @PostMapping("/kakao/register")
     public ApiResponse<AuthDto.LoginResponse> kakaoRegister(
-            @Valid @RequestBody AuthDto.KakaoRegisterRequest request
-    ) {
-        return ApiResponse.success(authService.registerWithKakao(request));
+            @Valid @RequestBody AuthDto.KakaoRegisterRequest request,
+            HttpServletResponse response) {
+        AuthService.LoginResult loginResult = authService.registerWithKakao(request);
+
+        // Refresh Token을 HttpOnly Cookie로 설정
+        setRefreshTokenCookie(response, loginResult.getRefreshToken());
+
+        return ApiResponse.success(loginResult.getLoginResponse());
     }
 
-    @Operation(summary = "로그아웃", description = "사용자를 로그아웃 처리합니다. (클라이언트에서 토큰 폐기 필요)")
+    @Operation(summary = "로그아웃", description = "사용자를 로그아웃 처리하고 Refresh Token 쿠키를 삭제합니다.")
     @PostMapping("/logout")
-    public ApiResponse<AuthDto.LogoutResponse> logout(@AuthenticationPrincipal User user) {
+    public ApiResponse<AuthDto.LogoutResponse> logout(
+            @AuthenticationPrincipal User user,
+            HttpServletResponse response) {
         authService.logout(user != null ? user.getId() : null);
+
+        // Refresh Token 쿠키 삭제
+        deleteRefreshTokenCookie(response);
+
         return ApiResponse.success(AuthDto.LogoutResponse.success());
+    }
+
+    @Operation(summary = "토큰 갱신", description = "Cookie의 Refresh Token을 사용하여 새로운 Access Token을 발급합니다.")
+    @PostMapping("/refresh")
+    public ApiResponse<AuthDto.RefreshResponse> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        // Cookie에서 Refresh Token 추출
+        String refreshToken = getRefreshTokenFromCookie(request);
+
+        AuthService.RefreshResult refreshResult = authService.refreshAccessToken(refreshToken);
+
+        // 새로운 Refresh Token을 Cookie로 설정
+        setRefreshTokenCookie(response, refreshResult.getRefreshToken());
+
+        return ApiResponse.success(refreshResult.getRefreshResponse());
+    }
+
+    /**
+     * Refresh Token을 HttpOnly Cookie로 설정
+     */
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true); // HTTPS에서만 전송
+        cookie.setPath("/");
+        cookie.setMaxAge((int) (refreshExpirationTime / 1000)); // 밀리초를 초로 변환
+        cookie.setAttribute("SameSite", "Strict"); // CSRF 방어
+        response.addCookie(cookie);
+    }
+
+    /**
+     * Refresh Token Cookie 삭제
+     */
+    private void deleteRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
+    /**
+     * Cookie에서 Refresh Token 추출
+     */
+    private String getRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        throw new IllegalArgumentException("Refresh Token이 없습니다. 다시 로그인해주세요.");
     }
 
 }

--- a/src/main/java/com/example/wagemanager/api/auth/dto/AuthDto.java
+++ b/src/main/java/com/example/wagemanager/api/auth/dto/AuthDto.java
@@ -41,6 +41,11 @@ public class AuthDto {
 
         @NotBlank(message = "사용자 유형은 필수입니다.")
         private String userType;
+
+        @NotBlank(message = "전화번호는 필수입니다.")
+        private String phone;
+
+        private String kakaoPayLink; // WORKER 타입인 경우 필수
     }
 
     /**
@@ -70,5 +75,18 @@ public class AuthDto {
                     .message("로그아웃되었습니다.")
                     .build();
         }
+    }
+
+
+    /**
+     * 토큰 갱신 응답 DTO
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(name = "AuthRefreshResponse")
+    public static class RefreshResponse {
+        private String accessToken;
     }
 }

--- a/src/main/java/com/example/wagemanager/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/wagemanager/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,48 @@
+package com.example.wagemanager.domain.auth.entity;
+
+import com.example.wagemanager.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * Refresh Token 엔티티
+ * 사용자별로 발급된 Refresh Token을 저장하고 관리
+ */
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token", nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    /**
+     * Refresh Token이 만료되었는지 확인
+     */
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    /**
+     * Refresh Token 업데이트
+     */
+    public void updateToken(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/example/wagemanager/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/wagemanager/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,32 @@
+package com.example.wagemanager.domain.auth.repository;
+
+import com.example.wagemanager.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    /**
+     * 토큰 문자열로 RefreshToken 조회
+     */
+    Optional<RefreshToken> findByToken(String token);
+
+    /**
+     * 사용자 ID로 RefreshToken 조회
+     */
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    /**
+     * 사용자 ID로 RefreshToken 삭제 (로그아웃 시 사용)
+     */
+    void deleteByUserId(Long userId);
+
+    /**
+     * 만료된 토큰 삭제 (배치 작업용)
+     */
+    void deleteByExpiresAtBefore(LocalDateTime dateTime);
+}

--- a/src/main/java/com/example/wagemanager/domain/auth/scheduler/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/com/example/wagemanager/domain/auth/scheduler/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,40 @@
+package com.example.wagemanager.domain.auth.scheduler;
+
+import com.example.wagemanager.domain.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 만료된 Refresh Token을 주기적으로 삭제하는 스케줄러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 매일 새벽 3시에 만료된 Refresh Token 삭제
+     * cron 표현식: 초(0) 분(0) 시(0) 일(*) 월(*) 요일(*)
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void cleanupExpiredTokens() {
+        log.info("만료된 Refresh Token 정리 작업 시작");
+
+        try {
+            LocalDateTime now = LocalDateTime.now();
+            refreshTokenRepository.deleteByExpiresAtBefore(now);
+
+            log.info("만료된 Refresh Token 정리 작업 완료");
+        } catch (Exception e) {
+            log.error("만료된 Refresh Token 정리 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/example/wagemanager/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wagemanager/domain/auth/service/AuthService.java
@@ -2,6 +2,8 @@ package com.example.wagemanager.domain.auth.service;
 
 import com.example.wagemanager.api.auth.dto.AuthDto;
 import com.example.wagemanager.common.exception.NotFoundException;
+import com.example.wagemanager.domain.auth.entity.RefreshToken;
+import com.example.wagemanager.domain.auth.repository.RefreshTokenRepository;
 import com.example.wagemanager.domain.user.dto.UserDto;
 import com.example.wagemanager.domain.user.entity.User;
 import com.example.wagemanager.domain.user.enums.UserType;
@@ -10,10 +12,15 @@ import com.example.wagemanager.domain.user.service.UserService;
 import com.example.wagemanager.global.oauth.kakao.KakaoOAuthClient;
 import com.example.wagemanager.global.oauth.kakao.dto.KakaoUserInfo;
 import com.example.wagemanager.global.security.JwtTokenProvider;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -23,9 +30,32 @@ public class AuthService {
     private final UserRepository userRepository;
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 로그인 결과 (응답 DTO + Refresh Token)
+     */
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class LoginResult {
+        private AuthDto.LoginResponse loginResponse;
+        private String refreshToken;
+    }
+
+    /**
+     * 토큰 갱신 결과 (응답 DTO + Refresh Token)
+     */
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class RefreshResult {
+        private AuthDto.RefreshResponse refreshResponse;
+        private String refreshToken;
+    }
 
     @Transactional
-    public AuthDto.LoginResponse loginWithKakao(String kakaoAccessToken) {
+    public LoginResult loginWithKakao(String kakaoAccessToken) {
         if (!StringUtils.hasText(kakaoAccessToken)) {
             throw new IllegalArgumentException("카카오 액세스 토큰은 필수입니다.");
         }
@@ -44,20 +74,98 @@ public class AuthService {
         updateProfileIfEmpty(user, userInfo);
 
         String accessToken = jwtTokenProvider.generateToken(user.getId());
+        String refreshToken = createOrUpdateRefreshToken(user.getId());
 
-        return AuthDto.LoginResponse.builder()
+        AuthDto.LoginResponse loginResponse = AuthDto.LoginResponse.builder()
                 .accessToken(accessToken)
                 .userId(user.getId())
                 .name(user.getName())
                 .userType(user.getUserType().name())
                 .build();
+
+        return LoginResult.builder()
+                .loginResponse(loginResponse)
+                .refreshToken(refreshToken)
+                .build();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void logout(Long userId) {
         if (userId == null) {
             throw new IllegalArgumentException("로그인이 필요합니다.");
         }
+        // Refresh Token 삭제
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+
+    /**
+     * Refresh Token을 사용하여 새로운 Access Token과 Refresh Token 발급
+     */
+    @Transactional
+    public RefreshResult refreshAccessToken(String refreshTokenString) {
+        if (!StringUtils.hasText(refreshTokenString)) {
+            throw new IllegalArgumentException("Refresh Token은 필수입니다.");
+        }
+
+        // Refresh Token 검증
+        if (!jwtTokenProvider.validateToken(refreshTokenString)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        // DB에서 Refresh Token 조회
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
+                .orElseThrow(() -> new NotFoundException("REFRESH_TOKEN_NOT_FOUND", "Refresh Token을 찾을 수 없습니다."));
+
+        // 만료 확인
+        if (refreshToken.isExpired()) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new IllegalArgumentException("만료된 Refresh Token입니다. 다시 로그인해주세요.");
+        }
+
+        // 사용자 확인
+        User user = userRepository.findById(refreshToken.getUserId())
+                .orElseThrow(() -> new NotFoundException("USER_NOT_FOUND", "사용자를 찾을 수 없습니다."));
+
+        // 새로운 Access Token 및 Refresh Token 생성
+        String newAccessToken = jwtTokenProvider.generateToken(user.getId());
+        String newRefreshToken = createOrUpdateRefreshToken(user.getId());
+
+        AuthDto.RefreshResponse refreshResponse = AuthDto.RefreshResponse.builder()
+                .accessToken(newAccessToken)
+                .build();
+
+        return RefreshResult.builder()
+                .refreshResponse(refreshResponse)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
+    /**
+     * Refresh Token 생성 또는 업데이트
+     */
+    private String createOrUpdateRefreshToken(Long userId) {
+        String refreshTokenString = jwtTokenProvider.generateRefreshToken(userId);
+        LocalDateTime expiresAt = LocalDateTime.now()
+                .plusSeconds(jwtTokenProvider.getRefreshExpirationTime() / 1000);
+
+        // 기존 Refresh Token 조회
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(userId)
+                .orElse(null);
+
+        if (refreshToken == null) {
+            // 새로 생성
+            refreshToken = RefreshToken.builder()
+                    .userId(userId)
+                    .token(refreshTokenString)
+                    .expiresAt(expiresAt)
+                    .build();
+        } else {
+            // 기존 토큰 업데이트
+            refreshToken.updateToken(refreshTokenString, expiresAt);
+        }
+
+        refreshTokenRepository.save(refreshToken);
+        return refreshTokenString;
     }
 
     private void updateProfileIfEmpty(User user, KakaoUserInfo kakaoUserInfo) {
@@ -71,7 +179,7 @@ public class AuthService {
     }
 
     @Transactional
-    public AuthDto.LoginResponse registerWithKakao(AuthDto.KakaoRegisterRequest request) {
+    public LoginResult registerWithKakao(AuthDto.KakaoRegisterRequest request) {
         if (!StringUtils.hasText(request.getKakaoAccessToken())) {
             throw new IllegalArgumentException("카카오 액세스 토큰은 필수입니다.");
         }
@@ -85,23 +193,37 @@ public class AuthService {
             throw new IllegalArgumentException("이미 가입된 카카오 계정입니다.");
         }
 
+        UserType userType = parseUserType(request.getUserType());
+
+        // WORKER 타입인 경우 카카오페이 링크 필수 검증
+        if (userType == UserType.WORKER && !StringUtils.hasText(request.getKakaoPayLink())) {
+            throw new IllegalArgumentException("근로자 타입은 카카오페이 링크가 필수입니다.");
+        }
+
         UserDto.RegisterRequest registerRequest = UserDto.RegisterRequest.builder()
                 .kakaoId(userInfo.kakaoId())
                 .name(resolveDisplayName(userInfo))
-                .phone(normalizePhoneNumber(userInfo.phoneNumber()))
+                .phone(request.getPhone())
                 .profileImageUrl(userInfo.profileImageUrl())
-                .userType(parseUserType(request.getUserType()))
+                .userType(userType)
+                .kakaoPayLink(request.getKakaoPayLink())
                 .build();
 
         UserDto.RegisterResponse registerResponse = userService.register(registerRequest);
 
-        String token = jwtTokenProvider.generateToken(registerResponse.getUserId());
+        String accessToken = jwtTokenProvider.generateToken(registerResponse.getUserId());
+        String refreshToken = createOrUpdateRefreshToken(registerResponse.getUserId());
 
-        return AuthDto.LoginResponse.builder()
-                .accessToken(token)
+        AuthDto.LoginResponse loginResponse = AuthDto.LoginResponse.builder()
+                .accessToken(accessToken)
                 .userId(registerResponse.getUserId())
                 .name(registerResponse.getName())
                 .userType(registerResponse.getUserType().name())
+                .build();
+
+        return LoginResult.builder()
+                .loginResponse(loginResponse)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/example/wagemanager/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/wagemanager/global/security/JwtTokenProvider.java
@@ -17,12 +17,15 @@ public class JwtTokenProvider {
 
     private final SecretKey secretKey;
     private final long expirationTime;
+    private final long refreshExpirationTime;
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secret,
-            @Value("${jwt.expiration}") long expirationTime) {
+            @Value("${jwt.expiration}") long expirationTime,
+            @Value("${jwt.refresh-expiration}") long refreshExpirationTime) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.expirationTime = expirationTime;
+        this.refreshExpirationTime = refreshExpirationTime;
     }
 
     /**
@@ -72,5 +75,30 @@ public class JwtTokenProvider {
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    /**
+     * Refresh Token 생성
+     * @param userId 사용자 ID
+     * @return Refresh Token 문자열
+     */
+    public String generateRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshExpirationTime);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /**
+     * Refresh Token의 만료 시간 반환 (밀리초)
+     * @return Refresh Token 만료 시간
+     */
+    public long getRefreshExpirationTime() {
+        return refreshExpirationTime;
     }
 }

--- a/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/health", "/h2-console/**").permitAll()
-                .requestMatchers("/api/auth/kakao/login", "/api/auth/kakao/register").permitAll()
+                .requestMatchers("/api/auth/kakao/login", "/api/auth/kakao/register", "/api/auth/refresh").permitAll()
                 .requestMatchers("/api/users/register").permitAll()
                 .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
- RefreshToken 엔티티 및 Repository 추가
- HttpOnly Cookie를 통한 Refresh Token 관리
- 토큰 갱신 API 엔드포인트 추가 (/api/auth/refresh)
- 로그아웃 시 Refresh Token 삭제 처리
- 만료된 Refresh Token 자동 정리 스케줄러 추가
- 회원가입 시 전화번호 및 카카오페이 링크 필수 입력 처리
- JwtTokenProvider에 Refresh Token 생성 기능 추가