### PR TITLE
feat: 근무 일정 승인 워크플로우 및 통합 조회 API 구현

### DIFF
--- a/src/main/java/com/example/wagemanager/api/correctionrequest/EmployerCorrectionRequestController.java
+++ b/src/main/java/com/example/wagemanager/api/correctionrequest/EmployerCorrectionRequestController.java
@@ -4,6 +4,8 @@ import com.example.wagemanager.common.dto.ApiResponse;
 import com.example.wagemanager.domain.correction.dto.CorrectionRequestDto;
 import com.example.wagemanager.domain.correction.enums.CorrectionStatus;
 import com.example.wagemanager.domain.correction.service.CorrectionRequestService;
+import com.example.wagemanager.domain.workrecord.dto.PendingApprovalDto;
+import com.example.wagemanager.domain.workrecord.service.WorkRecordQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,6 +22,18 @@ import java.util.List;
 public class EmployerCorrectionRequestController {
 
     private final CorrectionRequestService correctionRequestService;
+    private final WorkRecordQueryService workRecordQueryService;
+
+    @Operation(summary = "승인 대기중인 모든 요청 조회 (통합)",
+               description = "사업장의 승인 대기중인 근무 생성 요청과 정정 요청을 통합하여 조회합니다. 필터를 통해 특정 타입만 조회할 수 있습니다.")
+    @PreAuthorize("@correctionRequestPermission.canAccessWorkplaceCorrectionRequests(#workplaceId)")
+    @GetMapping("/workplaces/{workplaceId}/pending-approvals")
+    public ApiResponse<PendingApprovalDto.Response> getPendingApprovals(
+            @Parameter(description = "사업장 ID", required = true) @PathVariable Long workplaceId,
+            @Parameter(description = "필터 타입 (ALL: 전체, CORRECTION: 정정요청만, CREATION: 생성요청만)") @RequestParam(required = false, defaultValue = "ALL") PendingApprovalDto.FilterType filter) {
+        return ApiResponse.success(
+                workRecordQueryService.getAllPendingApprovalsByWorkplace(workplaceId, filter));
+    }
 
     @Operation(summary = "사업장별 정정요청 목록 조회", description = "특정 사업장의 정정요청 목록을 조회합니다.")
     @PreAuthorize("@correctionRequestPermission.canAccessWorkplaceCorrectionRequests(#workplaceId)")

--- a/src/main/java/com/example/wagemanager/api/workrecord/EmployerWorkRecordController.java
+++ b/src/main/java/com/example/wagemanager/api/workrecord/EmployerWorkRecordController.java
@@ -30,8 +30,7 @@ public class EmployerWorkRecordController {
     @PostMapping
     public ApiResponse<WorkRecordDto.Response> createWorkRecord(
             @Valid @RequestBody WorkRecordDto.CreateRequest request) {
-        // TODO: 근로자에게 근무 일정 생성 알람 전송
-        return ApiResponse.success(workRecordCommandService.createWorkRecord(request));
+        return ApiResponse.success(workRecordCommandService.createWorkRecordByEmployer(request));
     }
 
     @Operation(summary = "근무 기록 조회 (캘린더)", description = "특정 사업장의 기간별 근무 기록을 캘린더 형식으로 조회합니다.")
@@ -53,7 +52,7 @@ public class EmployerWorkRecordController {
         return ApiResponse.success(workRecordQueryService.getWorkRecordById(id));
     }
 
-    @Operation(summary = "근무 일정 수정", description = "등록된 근무 일정 정보를 수정합니다.")
+    @Operation(summary = "근무 일정 수정", description = "등록된 근무 일정 정보를 수정합니다. 수정 시 근로자에게 알람이 전송됩니다.")
     @PreAuthorize("@workRecordPermission.canAccessAsEmployer(#id)")
     @PutMapping("/{id}")
     public ApiResponse<WorkRecordDto.Response> updateWorkRecord(
@@ -71,12 +70,29 @@ public class EmployerWorkRecordController {
         return ApiResponse.success(null);
     }
 
-    @Operation(summary = "근무 일정 삭제", description = "등록된 근무 일정을 삭제합니다.")
+    @Operation(summary = "근무 일정 삭제", description = "등록된 근무 일정을 삭제합니다. 삭제 시 근로자에게 알람이 전송됩니다.")
     @PreAuthorize("@workRecordPermission.canAccessAsEmployer(#id)")
     @DeleteMapping("/{id}")
     public ApiResponse<Void> deleteWorkRecord(
             @Parameter(description = "근무 기록 ID", required = true) @PathVariable Long id) {
         workRecordCommandService.deleteWorkRecord(id);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "근무 일정 승인", description = "근로자가 요청한 근무 일정을 승인합니다. 승인 시 근로자에게 알람이 전송됩니다.")
+    @PreAuthorize("@workRecordPermission.canAccessAsEmployer(#id)")
+    @PutMapping("/{id}/approve")
+    public ApiResponse<WorkRecordDto.Response> approveWorkRecord(
+            @Parameter(description = "근무 기록 ID", required = true) @PathVariable Long id) {
+        return ApiResponse.success(workRecordCommandService.approveWorkRecord(id));
+    }
+
+    @Operation(summary = "근무 일정 거절", description = "근로자가 요청한 근무 일정을 거절합니다. 거절 시 근로자에게 알람이 전송됩니다.")
+    @PreAuthorize("@workRecordPermission.canAccessAsEmployer(#id)")
+    @PutMapping("/{id}/reject")
+    public ApiResponse<Void> rejectWorkRecord(
+            @Parameter(description = "근무 기록 ID", required = true) @PathVariable Long id) {
+        workRecordCommandService.rejectWorkRecord(id);
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/example/wagemanager/api/workrecord/WorkerWorkRecordController.java
+++ b/src/main/java/com/example/wagemanager/api/workrecord/WorkerWorkRecordController.java
@@ -31,9 +31,9 @@ public class WorkerWorkRecordController {
     @PreAuthorize("@contractPermission.canAccessAsWorker(#request.contractId)")
     @PostMapping
     public ApiResponse<WorkRecordDto.Response> createWorkRecord(
+            @AuthenticationPrincipal User worker,
             @Valid @RequestBody WorkRecordDto.CreateRequest request) {
-        // TODO: 고용주에게 근무 일정 생성 승인 요청 알람 전송 및 승인 대기 상태로 생성
-        return ApiResponse.success(workRecordCommandService.createWorkRecord(request));
+        return ApiResponse.success(workRecordCommandService.createWorkRecordByWorker(worker, request));
     }
 
     @Operation(summary = "내 근무 일정 조회", description = "로그인한 근로자의 기간별 근무 일정을 조회합니다.")

--- a/src/main/java/com/example/wagemanager/domain/allowance/entity/WeeklyAllowance.java
+++ b/src/main/java/com/example/wagemanager/domain/allowance/entity/WeeklyAllowance.java
@@ -3,6 +3,7 @@ package com.example.wagemanager.domain.allowance.entity;
 import com.example.wagemanager.common.BaseEntity;
 import com.example.wagemanager.domain.contract.entity.WorkerContract;
 import com.example.wagemanager.domain.workrecord.entity.WorkRecord;
+import com.example.wagemanager.domain.workrecord.enums.WorkRecordStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -84,8 +85,10 @@ public class WeeklyAllowance extends BaseEntity {
     private BigDecimal overtimeAmount = BigDecimal.ZERO;
 
     // 주간 총 근무 시간 계산 (WorkRecord 기반)
+    // PENDING_APPROVAL 상태는 제외 (SCHEDULED, COMPLETED만 포함)
     public void calculateTotalWorkHours() {
         this.totalWorkHours = this.workRecords.stream()
+                .filter(wr -> wr.getStatus() != WorkRecordStatus.PENDING_APPROVAL)
                 .map(WorkRecord::getTotalHours)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }

--- a/src/main/java/com/example/wagemanager/domain/correction/dto/CorrectionRequestDto.java
+++ b/src/main/java/com/example/wagemanager/domain/correction/dto/CorrectionRequestDto.java
@@ -2,6 +2,7 @@ package com.example.wagemanager.domain.correction.dto;
 
 import com.example.wagemanager.domain.correction.entity.CorrectionRequest;
 import com.example.wagemanager.domain.correction.enums.CorrectionStatus;
+import com.example.wagemanager.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -24,7 +25,7 @@ public class CorrectionRequestDto {
         @NotNull(message = "근무 기록 ID는 필수입니다.")
         private Long workRecordId;
 
-        @NotNull(message = "요청 근무일은 필수입니다.")
+        @NotNull(message = "요청 근무 날짜는 필수입니다.")
         private LocalDate requestedWorkDate;
 
         @NotNull(message = "요청 시작 시간은 필수입니다.")
@@ -65,10 +66,7 @@ public class CorrectionRequestDto {
                     .requestedStartTime(request.getRequestedStartTime())
                     .requestedEndTime(request.getRequestedEndTime())
                     .status(request.getStatus())
-                    .requester(RequesterInfo.builder()
-                            .id(request.getRequester().getId())
-                            .name(request.getRequester().getName())
-                            .build())
+                    .requester(RequesterInfo.from(request.getRequester()))
                     .reviewedAt(request.getReviewedAt())
                     .createdAt(request.getCreatedAt())
                     .build();
@@ -104,10 +102,7 @@ public class CorrectionRequestDto {
                     .requestedStartTime(request.getRequestedStartTime())
                     .requestedEndTime(request.getRequestedEndTime())
                     .status(request.getStatus())
-                    .requester(RequesterInfo.builder()
-                            .id(request.getRequester().getId())
-                            .name(request.getRequester().getName())
-                            .build())
+                    .requester(RequesterInfo.from(request.getRequester()))
                     .workplaceName(request.getWorkRecord().getContract().getWorkplace().getName())
                     .createdAt(request.getCreatedAt())
                     .build();
@@ -118,9 +113,16 @@ public class CorrectionRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(name = "CorrectionRequestRequesterInfo")
+    @Schema(name = "RequesterInfo")
     public static class RequesterInfo {
         private Long id;
         private String name;
+
+        public static RequesterInfo from(User user) {
+            return RequesterInfo.builder()
+                    .id(user.getId())
+                    .name(user.getName())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/example/wagemanager/domain/notification/enums/NotificationActionType.java
+++ b/src/main/java/com/example/wagemanager/domain/notification/enums/NotificationActionType.java
@@ -18,6 +18,12 @@ public enum NotificationActionType {
     VIEW_WORK_RECORD,
 
     /**
+     * 근무 일정 승인/거절
+     * - 고용주: 근로자가 요청한 근무 일정 승인/거절 화면으로 이동
+     */
+    VIEW_PENDING_APPROVAL,
+
+    /**
      * 급여 상세 조회
      * - 급여 명세서 확인 (근로자)
      */

--- a/src/main/java/com/example/wagemanager/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/wagemanager/domain/notification/enums/NotificationType.java
@@ -2,6 +2,11 @@ package com.example.wagemanager.domain.notification.enums;
 
 public enum NotificationType {
     SCHEDULE_CHANGE,            // 근무시간/일정 변경
+    SCHEDULE_CREATED,           // 근무 일정 생성 (고용주가 생성 시)
+    SCHEDULE_APPROVAL_REQUEST,  // 근무 일정 승인 요청 (근로자가 생성 시)
+    SCHEDULE_APPROVED,          // 근무 일정 승인됨 (고용주가 승인 시)
+    SCHEDULE_REJECTED,          // 근무 일정 거절됨 (고용주가 거절 시)
+    SCHEDULE_DELETED,           // 근무 일정 삭제됨 (고용주가 삭제 시)
     CORRECTION_RESPONSE,        // 근무기록 정정 요청 승인/거절
     PAYMENT_DUE,                // 월급일/급여 지급 예정
     PAYMENT_SUCCESS,            // 급여 입금 완료

--- a/src/main/java/com/example/wagemanager/domain/workrecord/dto/PendingApprovalDto.java
+++ b/src/main/java/com/example/wagemanager/domain/workrecord/dto/PendingApprovalDto.java
@@ -1,0 +1,129 @@
+package com.example.wagemanager.domain.workrecord.dto;
+
+import com.example.wagemanager.domain.correction.entity.CorrectionRequest;
+import com.example.wagemanager.domain.user.entity.User;
+import com.example.wagemanager.domain.workrecord.entity.WorkRecord;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PendingApprovalDto {
+
+    // 필터 타입
+    public enum FilterType {
+        ALL,            // 전체 (기본값)
+        CORRECTION,     // 정정 요청만
+        CREATION        // 생성 요청만
+    }
+
+    // 통합 응답 (CorrectionRequest 목록 + WorkRecord 목록)
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "PendingApprovalResponse")
+    public static class Response {
+        private List<CorrectionRequestInfo> correctionRequests;  // 수정 요청 목록
+        private List<WorkRecordCreationInfo> workRecordCreations; // 생성 요청 목록
+    }
+
+    // 수정 요청 정보
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "CorrectionRequestInfo")
+    public static class CorrectionRequestInfo {
+        private Long id;                    // CorrectionRequest ID
+        private Long workRecordId;          // WorkRecord ID
+        private RequesterInfo requester;    // 요청자 정보
+        private String workplaceName;       // 사업장 이름
+
+        // 근무 정보
+        private LocalDate originalWorkDate;    // 원본 근무 날짜
+        private LocalTime originalStartTime;   // 원본 시작 시간
+        private LocalTime originalEndTime;     // 원본 종료 시간
+        private LocalDate requestedWorkDate;   // 요청 근무 날짜
+        private LocalTime requestedStartTime;  // 요청 시작 시간
+        private LocalTime requestedEndTime;    // 요청 종료 시간
+
+        private String status;              // 상태
+        private LocalDateTime createdAt;    // 요청 생성 시간
+
+        // CorrectionRequest로부터 생성
+        public static CorrectionRequestInfo from(CorrectionRequest request) {
+            return CorrectionRequestInfo.builder()
+                    .id(request.getId())
+                    .workRecordId(request.getWorkRecord().getId())
+                    .requester(RequesterInfo.from(request.getRequester()))
+                    .workplaceName(request.getWorkRecord().getContract().getWorkplace().getName())
+                    .originalWorkDate(request.getOriginalWorkDate())
+                    .originalStartTime(request.getOriginalStartTime())
+                    .originalEndTime(request.getOriginalEndTime())
+                    .requestedWorkDate(request.getRequestedWorkDate())
+                    .requestedStartTime(request.getRequestedStartTime())
+                    .requestedEndTime(request.getRequestedEndTime())
+                    .status(request.getStatus().name())
+                    .createdAt(request.getCreatedAt())
+                    .build();
+        }
+    }
+
+    // 생성 요청 정보
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "WorkRecordCreationInfo")
+    public static class WorkRecordCreationInfo {
+        private Long id;                    // WorkRecord ID
+        private RequesterInfo requester;    // 요청자 정보
+        private String workplaceName;       // 사업장 이름
+
+        // 근무 정보
+        private LocalDate requestedWorkDate;   // 요청 근무 날짜
+        private LocalTime requestedStartTime;  // 요청 시작 시간
+        private LocalTime requestedEndTime;    // 요청 종료 시간
+
+        private String status;              // 상태
+        private LocalDateTime createdAt;    // 요청 생성 시간
+
+        // WorkRecord(PENDING_APPROVAL)로부터 생성
+        public static WorkRecordCreationInfo from(WorkRecord workRecord) {
+            return WorkRecordCreationInfo.builder()
+                    .id(workRecord.getId())
+                    .requester(RequesterInfo.from(workRecord.getContract().getWorker().getUser()))
+                    .workplaceName(workRecord.getContract().getWorkplace().getName())
+                    .requestedWorkDate(workRecord.getWorkDate())
+                    .requestedStartTime(workRecord.getStartTime())
+                    .requestedEndTime(workRecord.getEndTime())
+                    .status(workRecord.getStatus().name())
+                    .createdAt(workRecord.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "RequesterInfo")
+    public static class RequesterInfo {
+        private Long id;
+        private String name;
+
+        public static RequesterInfo from(User user) {
+            return RequesterInfo.builder()
+                    .id(user.getId())
+                    .name(user.getName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/wagemanager/domain/workrecord/dto/WorkRecordDto.java
+++ b/src/main/java/com/example/wagemanager/domain/workrecord/dto/WorkRecordDto.java
@@ -183,4 +183,15 @@ public class WorkRecordDto {
         @Size(max = 500, message = "메모는 500자 이하로 입력해주세요.")
         private String memo;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "WorkRecordApprovalRequest", description = "근무 일정 승인/거절 요청")
+    public static class ApprovalRequest {
+        @NotNull(message = "승인 여부는 필수입니다.")
+        @Schema(description = "승인 여부 (true: 승인, false: 거절)", example = "true")
+        private Boolean approved;
+    }
 }

--- a/src/main/java/com/example/wagemanager/domain/workrecord/entity/WorkRecord.java
+++ b/src/main/java/com/example/wagemanager/domain/workrecord/entity/WorkRecord.java
@@ -154,6 +154,27 @@ public class WorkRecord extends BaseEntity {
         calculateTotalSalary();
     }
 
+    // 승인 처리 (PENDING_APPROVAL → SCHEDULED 또는 COMPLETED)
+    public void approve() {
+        if (this.status != WorkRecordStatus.PENDING_APPROVAL) {
+            throw new IllegalStateException("승인 대기 상태만 승인할 수 있습니다.");
+        }
+
+        // 근무 날짜가 과거면 COMPLETED, 미래면 SCHEDULED
+        if (this.workDate.isBefore(LocalDate.now())) {
+            this.status = WorkRecordStatus.COMPLETED;
+            calculateHours();
+            calculateTotalSalary();
+        } else {
+            this.status = WorkRecordStatus.SCHEDULED;
+        }
+    }
+
+    // 상태 확인
+    public boolean isPendingApproval() {
+        return this.status == WorkRecordStatus.PENDING_APPROVAL;
+    }
+
     // 근무 시간 분류 계산
     // 전체 근무 시간을 일반 근무, 야간 근무, 휴일 근무 시간으로 분류
     private void calculateHours() {

--- a/src/main/java/com/example/wagemanager/domain/workrecord/enums/WorkRecordStatus.java
+++ b/src/main/java/com/example/wagemanager/domain/workrecord/enums/WorkRecordStatus.java
@@ -1,6 +1,7 @@
 package com.example.wagemanager.domain.workrecord.enums;
 
 public enum WorkRecordStatus {
-    SCHEDULED,  // 예정 (근무 전)
-    COMPLETED   // 완료 (근무 후)
+    SCHEDULED,        // 예정 (고용주가 생성하거나 승인된 일정)
+    PENDING_APPROVAL, // 승인 대기 (근로자가 생성한 일정)
+    COMPLETED         // 완료 (근무 후)
 }

--- a/src/main/java/com/example/wagemanager/domain/workrecord/repository/WorkRecordRepository.java
+++ b/src/main/java/com/example/wagemanager/domain/workrecord/repository/WorkRecordRepository.java
@@ -73,4 +73,18 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
 
     @Query("SELECT c FROM WorkerContract c WHERE c.isActive = true")
     List<WorkerContract> findAllActiveContracts();
+
+    // 사업장별 승인 대기중인 근무 기록 조회
+    @Query("SELECT wr FROM WorkRecord wr " +
+            "JOIN FETCH wr.contract c " +
+            "JOIN FETCH c.workplace " +
+            "JOIN FETCH c.worker w " +
+            "JOIN FETCH w.user " +
+            "WHERE c.workplace.id = :workplaceId " +
+            "AND wr.status = :status " +
+            "ORDER BY wr.workDate ASC")
+    List<WorkRecord> findByWorkplaceAndStatus(
+            @Param("workplaceId") Long workplaceId,
+            @Param("status") WorkRecordStatus status
+    );
 }


### PR DESCRIPTION
- 근로자 생성 근무 일정 승인 기능 추가 (PENDING_APPROVAL 상태)
- 고용주/근로자 역할에 따른 근무 생성 로직 분리
- 승인 시 날짜 기반 상태 설정 (과거: COMPLETED, 미래: SCHEDULED)
- 통합 승인 대기 목록 API 구현 (정정 요청 + 생성 요청)
- 필터링 기능 추가 (ALL, CORRECTION, CREATION)
- 알림 시스템 통합 (생성, 승인 요청, 승인, 거절, 삭제)
- PENDING_APPROVAL 상태는 주휴수당 계산에서 제외