### PR TITLE
fix: JSON 파싱 오류 및 Jackson 버전 불일치 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.2'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/wagemanager/global/config/WebMvcConfig.java
+++ b/src/main/java/com/example/wagemanager/global/config/WebMvcConfig.java
@@ -1,0 +1,29 @@
+package com.example.wagemanager.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Spring MVC 설정
+ * Content Negotiation 전략을 JSON 우선으로 설정
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        configurer
+                // 기본 Content Type을 JSON으로 설정
+                .defaultContentType(MediaType.APPLICATION_JSON)
+                // URL 파라미터 기반 Content Negotiation 비활성화
+                .favorParameter(false)
+                // Accept 헤더 무시 안 함 (클라이언트가 명시한 Accept 헤더 존중)
+                .ignoreAcceptHeader(false)
+                // Accept 헤더가 없을 때 사용할 기본 미디어 타입
+                .defaultContentTypeStrategy(request -> {
+                    return java.util.List.of(MediaType.APPLICATION_JSON);
+                });
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,3 +32,8 @@ holiday.api.key=98a356373f5f9681be5f61493c91b110680df64e016d9c417ba17e0b8c618f17
 # Cache Configuration
 spring.cache.type=simple
 spring.cache.cache-names=holiday-check,holidays-by-year
+
+# Jackson Configuration - JSON 우선 설정
+spring.mvc.contentnegotiation.favor-path-extension=false
+spring.mvc.contentnegotiation.favor-parameter=false
+spring.mvc.contentnegotiation.media-types.json=application/json


### PR DESCRIPTION
- Content Negotiation을 JSON 우선으로 설정
- jackson-dataformat-xml 버전을 Spring Boot BOM에서 관리하도록 변경
- WebMvcConfig 추가: JSON을 기본 Content Type으로 설정
- application.properties에 Jackson JSON 우선 설정 추가