### PR TITLE
feat: 개발용 임시 로그인 API 추가

### DIFF
--- a/src/main/java/com/example/wagemanager/api/auth/AuthController.java
+++ b/src/main/java/com/example/wagemanager/api/auth/AuthController.java
@@ -84,6 +84,23 @@ public class AuthController {
         return ApiResponse.success(refreshResult.getRefreshResponse());
     }
 
+    @Operation(
+            summary = "[개발용] 임시 로그인",
+            description = "개발용 임시 로그인 API입니다. 실제 사용자 검증 없이 토큰을 발급합니다. " +
+                    "배포 환경에서는 반드시 비활성화해야 합니다."
+    )
+    @PostMapping("/dev/login")
+    public ApiResponse<AuthDto.LoginResponse> devLogin(
+            @Valid @RequestBody AuthDto.DevLoginRequest request,
+            HttpServletResponse response) {
+        AuthService.LoginResult loginResult = authService.devLogin(request);
+
+        // Refresh Token을 HttpOnly Cookie로 설정
+        setRefreshTokenCookie(response, loginResult.getRefreshToken());
+
+        return ApiResponse.success(loginResult.getLoginResponse());
+    }
+
     /**
      * Refresh Token을 HttpOnly Cookie로 설정
      */

--- a/src/main/java/com/example/wagemanager/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/example/wagemanager/domain/auth/dto/AuthDto.java
@@ -95,4 +95,27 @@ public class AuthDto {
     public static class RefreshResponse {
         private String accessToken;
     }
+
+    /**
+     * 개발용 임시 로그인 요청 DTO
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(name = "AuthDevLoginRequest")
+    public static class DevLoginRequest {
+        
+        @NotBlank(message = "사용자 ID는 필수입니다.")
+        @Schema(example = "1")
+        private String userId;
+
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        @Schema(example = "테스트 사용자")
+        private String name;
+
+        @NotBlank(message = "사용자 유형은 필수입니다.")
+        @Schema(example = "WORKER")
+        private String userType;
+    }
 }

--- a/src/main/java/com/example/wagemanager/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wagemanager/domain/auth/service/AuthService.java
@@ -190,4 +190,31 @@ public class AuthService {
             throw new BadRequestException(ErrorCode.INVALID_USER_TYPE, "유효하지 않은 사용자 유형입니다. EMPLOYER 또는 WORKER를 입력해주세요.");
         }
     }
+
+    /**
+     * 개발용 임시 로그인 (실제 사용자 조회/생성 없이 토큰 발급)
+     * 주의: 개발 환경에서만 사용하고 배포 환경에서는 반드시 비활성화 해야 함
+     *
+     * @param request 개발용 로그인 요청 DTO
+     * @return 로그인 결과 (응답 DTO + Refresh Token)
+     */
+    public LoginResult devLogin(AuthDto.DevLoginRequest request) {
+        Long userId = Long.parseLong(request.getUserId());
+        
+        // 토큰 생성
+        TokenService.TokenPair tokenPair = tokenService.generateTokenPair(userId);
+
+        // 응답 DTO 생성
+        AuthDto.LoginResponse loginResponse = AuthDto.LoginResponse.builder()
+                .accessToken(tokenPair.getAccessToken())
+                .userId(userId)
+                .name(request.getName())
+                .userType(request.getUserType())
+                .build();
+
+        return LoginResult.builder()
+                .loginResponse(loginResponse)
+                .refreshToken(tokenPair.getRefreshToken())
+                .build();
+    }
 }

--- a/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/wagemanager/global/security/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/health", "/h2-console/**").permitAll()
-                .requestMatchers("/api/auth/kakao/login", "/api/auth/kakao/register", "/api/auth/refresh").permitAll()
+                .requestMatchers("/api/auth/kakao/login", "/api/auth/kakao/register", "/api/auth/refresh", "/api/auth/dev/login").permitAll()
                 .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
- AuthDto에 DevLoginRequest DTO 추가
- AuthService에 devLogin() 메서드 추가
 - AuthController에 POST /api/auth/dev/login 엔드포인트 추가
- 개발 환경에서만 사용하도록 주석 표시 개발 중 테스트를 위해 실제 사용자 검증 없이 토큰을 발급하는 임시 로그인 API입니다.