### PR TITLE
[ZVXY-30] fix(config): jackson-dataformat-xml 의존성 충돌 해결

### DIFF
--- a/src/main/java/com/example/wagemanager/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/wagemanager/global/config/RestTemplateConfig.java
@@ -12,6 +12,9 @@ import org.springframework.web.client.RestTemplate;
  * 외부 API 호출 시 사용할 RestTemplate 설정
  * - 일반 RestTemplate: JSON 처리용
  * - XML RestTemplate: 공공 API XML 파싱용 (컨트롤러와 분리)
+ *
+ * 주의: XmlMapper를 Bean으로 등록하지 않음 (Spring Boot 자동 설정이
+ * MappingJackson2XmlHttpMessageConverter를 등록하는 것을 방지)
  */
 @Configuration
 public class RestTemplateConfig {
@@ -34,25 +37,22 @@ public class RestTemplateConfig {
      * XML 전용 RestTemplate
      * 공공 API XML 파싱용으로 별도 분리
      * 컨트롤러의 MessageConverter와 독립적으로 동작
+     *
+     * XmlMapper를 Bean으로 등록하지 않고 직접 생성하여 사용
+     * (Bean으로 등록하면 Spring Boot가 자동으로 XML 컨버터를 MVC에 추가함)
      */
     @Bean
-    public RestTemplate xmlRestTemplate(RestTemplateBuilder builder, XmlMapper xmlMapper) {
+    public RestTemplate xmlRestTemplate(RestTemplateBuilder builder) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(5000); // 5초
         factory.setReadTimeout(5000); // 5초
+
+        // XmlMapper를 직접 생성 (Bean으로 등록하지 않음)
+        XmlMapper xmlMapper = new XmlMapper();
 
         return builder
                 .requestFactory(() -> factory)
                 .additionalMessageConverters(new MappingJackson2XmlHttpMessageConverter(xmlMapper))
                 .build();
-    }
-
-    /**
-     * XmlMapper 빈
-     * XML 파싱용 (RestTemplate에서만 사용, 컨트롤러는 사용 안 함)
-     */
-    @Bean
-    public XmlMapper xmlMapper() {
-        return new XmlMapper();
     }
 }

--- a/src/main/java/com/example/wagemanager/global/config/WebMvcConfig.java
+++ b/src/main/java/com/example/wagemanager/global/config/WebMvcConfig.java
@@ -1,42 +1,72 @@
 package com.example.wagemanager.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.http.converter.ResourceHttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
  * Spring MVC 설정
  * - Content Negotiation 전략을 JSON 우선으로 설정
  * - 컨트롤러는 JSON만 처리하도록 XML MessageConverter 제거
+ *
+ * 문제: jackson-dataformat-xml 의존성이 있으면 Spring Boot가 자동으로
+ * MappingJackson2XmlHttpMessageConverter를 등록하여 JSON 요청이 XML로 파싱됨
+ *
+ * 해결: @EnableWebMvc로 Spring Boot 자동 설정 비활성화 후
+ * configureMessageConverters로 필요한 컨버터만 명시적으로 등록 (XML 제외)
  */
 @Configuration
+@EnableWebMvc
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final ObjectMapper objectMapper;
+
+    public WebMvcConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
         configurer
-                // 기본 Content Type을 JSON으로 설정
                 .defaultContentType(MediaType.APPLICATION_JSON)
-                // URL 파라미터 기반 Content Negotiation 비활성화
                 .favorParameter(false)
-                // Accept 헤더 무시 안 함 (클라이언트가 명시한 Accept 헤더 존중)
-                .ignoreAcceptHeader(false)
-                // Accept 헤더가 없을 때 사용할 기본 미디어 타입
-                .defaultContentTypeStrategy(request -> {
-                    return java.util.List.of(MediaType.APPLICATION_JSON);
-                });
+                .ignoreAcceptHeader(false);
     }
 
+    /**
+     * 메시지 컨버터를 명시적으로 설정하여 XML 컨버터를 완전히 제외
+     * configureMessageConverters는 Spring Boot의 기본 컨버터 설정을 완전히 대체함
+     */
     @Override
-    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
-        // XML MessageConverter 제거 - 컨트롤러는 JSON만 처리
-        // RestTemplate/WebClient에서는 별도로 XmlMapper를 설정하여 XML 파싱 가능
-        // extendMessageConverters는 Spring Boot가 기본 컨버터를 모두 추가한 후에 호출됨
-        converters.removeIf(converter -> converter instanceof MappingJackson2XmlHttpMessageConverter);
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        // 기본 컨버터들 추가 (XML 제외)
+        converters.add(new ByteArrayHttpMessageConverter());
+
+        StringHttpMessageConverter stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
+        stringConverter.setWriteAcceptCharset(false);
+        converters.add(stringConverter);
+
+        converters.add(new ResourceHttpMessageConverter());
+        converters.add(new AllEncompassingFormHttpMessageConverter());
+
+        // JSON 컨버터 - Spring Boot의 ObjectMapper 사용 (JSR-310 등 모듈 포함)
+        MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter(objectMapper);
+        converters.add(jsonConverter);
+
+        // XML 컨버터는 의도적으로 추가하지 않음
+        // jackson-dataformat-xml은 RestTemplate에서 공공 API XML 응답 파싱에만 사용
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,6 @@ holiday.api.key=98a356373f5f9681be5f61493c91b110680df64e016d9c417ba17e0b8c618f17
 spring.cache.type=simple
 spring.cache.cache-names=holiday-check,holidays-by-year
 
-# Jackson Configuration - JSON 우선 설정
-spring.mvc.contentnegotiation.favor-path-extension=false
-spring.mvc.contentnegotiation.favor-parameter=false
-spring.mvc.contentnegotiation.media-types.json=application/json
+# Jackson Configuration - XML 컨버터 비활성화
+spring.mvc.converters.preferred-json-mapper=jackson
+spring.http.converters.preferred-json-mapper=jackson


### PR DESCRIPTION
- XmlMapper Bean 제거, xmlRestTemplate 내부에서 직접 생성
- WebMvcConfig에 @EnableWebMvc 추가하여 자동 설정 비활성화
- configureMessageConverters로 XML 컨버터 제외한 컨버터만 등록
- JSON 요청 파싱 오류 및 XML 응답 반환 문제 해결

[ZVXY-30]

**문제 상황**
공휴일 정보를 가져오기 위해 공공 API를 연동했는데, 해당 API가 XML 형식으로 응답을 반환합니다. 이를 파싱하기 위해 jackson-dataformat-xml 의존성을 추가했습니다. 그런데 Spring Boot의 자동 설정(Auto Configuration)이 이 의존성을 감지하고 MappingJackson2XmlHttpMessageConverter를 MVC의 MessageConverter 목록에 자동 등록해버렸습니다. 그 결과, 모든 REST API가 XML을 우선적으로 처리하게 되는 문제가 발생했습니다.

**증상**
요청 파싱 실패: 프론트엔드에서 JSON으로 요청을 보내면 Unexpected character '{' in prolog; expected '<' 에러 발생 (XML 파서가 JSON을 파싱하려고 시도)
응답 포맷 변경: GET 요청의 응답이 JSON이 아닌 XML로 반환됨

**원인 분석**
XmlMapper를 @Bean으로 등록하면 Spring Boot가 이를 감지하여 XML MessageConverter를 전역으로 활성화합니다. extendMessageConverters로 제거를 시도해도 Spring Boot가 재등록하는 문제가 있었습니다.

**해결 방법**
1. XmlMapper Bean 등록 제거 RestTemplateConfig에서 XmlMapper를 Bean으로 등록하지 않고, xmlRestTemplate 메서드 내부에서 지역 변수로 생성하여 사용하도록 변경했습니다. 이렇게 하면 Spring Boot의 자동 설정이 트리거되지 않습니다. 
2. @EnableWebMvc로 자동 설정 비활성화 WebMvcConfig에 @EnableWebMvc를 추가하여 Spring Boot의 WebMvc 자동 설정을 비활성화했습니다. 
3. MessageConverter 명시적 등록 configureMessageConverters를 오버라이드하여 필요한 컨버터만 직접 등록하고, XML 컨버터는 의도적으로 제외했습니다.

**결과**
REST API: JSON만 처리 (XML 컨버터 제외)
공휴일 API 호출: xmlRestTemplate을 통해 XML 파싱 가능
컨트롤러와 외부 API 호출의 역할을 명확히 분리하여 의존성 충돌 문제를 해결했습니다.

[ZVXY-30]: https://yonggeun.atlassian.net/browse/ZVXY-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ