### PR TITLE
[ZVXY-31] fix(swagger): 에러 응답 스키마 불일치 수정

### DIFF
--- a/src/main/java/com/example/wagemanager/global/config/OpenApiConfig.java
+++ b/src/main/java/com/example/wagemanager/global/config/OpenApiConfig.java
@@ -2,9 +2,15 @@ package com.example.wagemanager.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,7 +26,8 @@ public class OpenApiConfig {
                         .name(jwt)
                         .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
-                        .bearerFormat("JWT"));
+                        .bearerFormat("JWT"))
+                .addSchemas("ApiErrorResponse", createErrorResponseSchema());
 
         return new OpenAPI()
                 .info(new Info()
@@ -29,5 +36,70 @@ public class OpenApiConfig {
                         .version("v1.0"))
                 .addSecurityItem(securityRequirement)
                 .components(components);
+    }
+
+    /**
+     * 에러 응답 스키마 정의
+     * API_SPECIFICATION.md에 정의된 에러 응답 포맷과 일치
+     */
+    @SuppressWarnings("rawtypes")
+    private Schema createErrorResponseSchema() {
+        Schema errorDetailSchema = new Schema<>()
+                .type("object")
+                .addProperty("code", new Schema<>().type("string").example("NOT_FOUND"))
+                .addProperty("message", new Schema<>().type("string").example("리소스를 찾을 수 없습니다."));
+
+        return new Schema<>()
+                .type("object")
+                .addProperty("success", new Schema<>().type("boolean").example(false))
+                .addProperty("data", new Schema<>().type("object").nullable(true).example(null))
+                .addProperty("error", errorDetailSchema);
+    }
+
+    /**
+     * 모든 API에 공통 에러 응답 추가
+     * 기존 응답이 있더라도 에러 응답 스키마로 덮어씌움
+     */
+    @Bean
+    public OperationCustomizer globalErrorResponseCustomizer() {
+        return (operation, handlerMethod) -> {
+            ApiResponses responses = operation.getResponses();
+            if (responses == null) {
+                responses = new ApiResponses();
+                operation.setResponses(responses);
+            }
+
+            // 에러 응답용 Content 생성 (매번 새로 생성해야 함)
+            // 400 Bad Request
+            responses.addApiResponse("400", new ApiResponse()
+                    .description("잘못된 요청")
+                    .content(createErrorContent()));
+
+            // 401 Unauthorized
+            responses.addApiResponse("401", new ApiResponse()
+                    .description("인증 실패")
+                    .content(createErrorContent()));
+
+            // 404 Not Found
+            responses.addApiResponse("404", new ApiResponse()
+                    .description("리소스를 찾을 수 없음")
+                    .content(createErrorContent()));
+
+            // 500 Internal Server Error
+            responses.addApiResponse("500", new ApiResponse()
+                    .description("서버 오류")
+                    .content(createErrorContent()));
+
+            return operation;
+        };
+    }
+
+    /**
+     * 에러 응답용 Content 생성
+     */
+    private Content createErrorContent() {
+        return new Content()
+                .addMediaType("application/json", new MediaType()
+                        .schema(new Schema<>().$ref("#/components/schemas/ApiErrorResponse")));
     }
 }


### PR DESCRIPTION
- OpenApiConfig에 ApiErrorResponse 스키마 정의 추가
- OperationCustomizer로 모든 API에 공통 에러 응답(400, 401, 404, 500) 추가
- 에러 응답에 올바른 스키마(success: false, error 객체) 표시되도록 수정
- 기존 ApiResponse.ErrorResponse와 이름 충돌 방지를 위해 ApiErrorResponse로 명명

[ZVXY-31]

**문제 상황**
Swagger UI에서 400, 401, 404 등 에러 상황의 응답 예시를 확인하면, 성공 응답 스키마(success: true)가 그대로 노출되는 문제가 발생했습니다. 컨트롤러의 반환 타입이 제네릭(ApiResponse<T>)으로 설정되어 있어서 SpringDoc이 에러 상황에도 동일한 스키마를 매핑했습니다.

**증상**
에러 응답(4xx, 5xx)에 success: true인 성공 응답 스키마가 표시됨
API 명세서(API_SPECIFICATION.md)에 정의된 에러 응답 포맷과 Swagger UI가 불일치

**원인 분석**
SpringDoc이 컨트롤러의 반환 타입인 ApiResponse<T>를 기준으로 모든 응답 스키마를 자동 생성합니다. 에러 응답을 별도로 정의하지 않으면 성공 응답 스키마가 그대로 적용됩니다.

**해결 방법**
1. ApiErrorResponse 스키마 정의 OpenApiConfig에서 에러 응답용 스키마(success: false, data: null, error 객체)를 별도로 정의했습니다.
2. 기존 ApiResponse.ErrorResponse와 이름 충돌을 방지하기 위해 ApiErrorResponse로 명명했습니다.
3. OperationCustomizer로 전역 에러 응답 추가 모든 API에 공통으로 400, 401, 404, 500 에러 응답을 추가하는 OperationCustomizer Bean을 등록했습니다.
4. 에러 응답 스키마 강제 적용 기존에 SpringDoc이 자동 생성한 에러 응답을 덮어씌워 올바른 ApiErrorResponse 스키마가 표시되도록 했습니다.

**결과**
성공 응답(200): 기존 ApiResponse<T> 스키마 유지
에러 응답(400, 401, 404, 500): success: false, error 객체가 포함된 올바른 스키마 표시
API 명세서와 Swagger UI의 일관성 확보

[ZVXY-31]: https://yonggeun.atlassian.net/browse/ZVXY-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ