### PR TITLE
[ZVXY-33] fix(config): 기본 RestTemplate bean 명시

### DIFF
--- a/src/main/java/com/example/wagemanager/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/wagemanager/global/config/RestTemplateConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
@@ -23,6 +24,7 @@ public class RestTemplateConfig {
      * 일반 RestTemplate (JSON 처리용)
      */
     @Bean
+    @Primary
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(5000); // 5초


### PR DESCRIPTION
카카오 로그인 API에서 Spring Context 로딩 시 RestTemplate 타입의 Bean이 2개 발견되어 의존성 주입(DI) 실패 오류가 발생하고 있습니다.

기본 RestTemplate bean 명시를 통해 오류 해결