### PR TITLE
[ZVXY-35] fix(oauth): 카카오 사용자 정보 응답 구조 수정

### DIFF
--- a/src/main/java/com/example/wagemanager/global/oauth/kakao/dto/KakaoUserResponse.java
+++ b/src/main/java/com/example/wagemanager/global/oauth/kakao/dto/KakaoUserResponse.java
@@ -16,16 +16,18 @@ public class KakaoUserResponse {
     @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoAccount {
-        private String name;
+        private KakaoProfile profile;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoProfile {
+        private String nickname;
     }
 
     public KakaoUserInfo toUserInfo() {
-        String kakaoIdValue = id != null ? String.valueOf(id) : null;
-        String nameValue = null;
-
-        if (kakaoAccount != null) {
-            nameValue = kakaoAccount.getName();
-        }
+        String kakaoIdValue = String.valueOf(id);
+        String nameValue = kakaoAccount.getProfile().getNickname();
 
         return KakaoUserInfo.builder()
                 .kakaoId(kakaoIdValue)


### PR DESCRIPTION
kakao_account.name에서 kakao_account.profile.nickname으로 변경하여 실제 카카오 API 응답 구조에 맞게 수정