### PR TITLE
fix: 계약 정보 수정 시 외래 키 제약 조건 오류 수정

### DIFF
--- a/src/main/java/com/example/wagemanager/domain/correction/repository/CorrectionRequestRepository.java
+++ b/src/main/java/com/example/wagemanager/domain/correction/repository/CorrectionRequestRepository.java
@@ -4,6 +4,7 @@ import com.example.wagemanager.domain.correction.entity.CorrectionRequest;
 import com.example.wagemanager.domain.correction.enums.CorrectionStatus;
 import com.example.wagemanager.domain.correction.enums.RequestType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -120,5 +121,17 @@ public interface CorrectionRequestRepository extends JpaRepository<CorrectionReq
             @Param("workDate") LocalDate workDate,
             @Param("startTime") LocalTime startTime,
             @Param("endTime") LocalTime endTime
+    );
+
+    // 계약 정보 변경 시 미래 WorkRecord를 참조하는 CorrectionRequest 삭제
+    @Modifying
+    @Query("DELETE FROM CorrectionRequest cr " +
+            "WHERE cr.workRecord.id IN " +
+            "(SELECT wr.id FROM WorkRecord wr WHERE wr.contract.id = :contractId " +
+            "AND wr.workDate > :date AND wr.status = :status)")
+    void deleteByWorkRecordContractAndDateAfterAndStatus(
+            @Param("contractId") Long contractId,
+            @Param("date") LocalDate date,
+            @Param("status") com.example.wagemanager.domain.workrecord.enums.WorkRecordStatus status
     );
 }

--- a/src/main/java/com/example/wagemanager/domain/workrecord/repository/WorkRecordRepository.java
+++ b/src/main/java/com/example/wagemanager/domain/workrecord/repository/WorkRecordRepository.java
@@ -4,6 +4,7 @@ import com.example.wagemanager.domain.workrecord.entity.WorkRecord;
 import com.example.wagemanager.domain.workrecord.enums.WorkRecordStatus;
 import com.example.wagemanager.domain.contract.entity.WorkerContract;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -100,6 +101,7 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
     );
 
     // 계약 정보 변경 시 미래 WorkRecord 삭제
+    @Modifying
     @Query("DELETE FROM WorkRecord wr " +
             "WHERE wr.contract.id = :contractId " +
             "AND wr.workDate > :date " +


### PR DESCRIPTION
- WorkRecordRepository에 @Modifying 어노테이션 추가
- 계약 변경 시 참조 무결성 보장을 위해 CorrectionRequest 선삭제 로직 추가
- 미래 WorkRecord 삭제 전 관련 CorrectionRequest 자동 삭제 처리


고용주 페이지 테스트중 근무 기록 수정에서 발생한 오류 수정 내역입니다.