### PR TITLE
[fix] swagger 요청/응답 형식 수정

### DIFF
--- a/src/main/java/com/example/paycheck/domain/correction/dto/CorrectionRequestDto.java
+++ b/src/main/java/com/example/paycheck/domain/correction/dto/CorrectionRequestDto.java
@@ -4,6 +4,7 @@ import com.example.paycheck.domain.correction.entity.CorrectionRequest;
 import com.example.paycheck.domain.correction.enums.CorrectionStatus;
 import com.example.paycheck.domain.correction.enums.RequestType;
 import com.example.paycheck.domain.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -36,9 +37,13 @@ public class CorrectionRequestDto {
         private LocalDate requestedWorkDate;
 
         @NotNull(message = "요청 시작 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime requestedStartTime;
 
         @NotNull(message = "요청 종료 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime requestedEndTime;
 
         // CREATE 타입에서 선택적
@@ -58,10 +63,18 @@ public class CorrectionRequestDto {
         private Long workRecordId;
         private Long contractId;
         private LocalDate originalWorkDate;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime originalStartTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime originalEndTime;
         private LocalDate requestedWorkDate;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime requestedStartTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime requestedEndTime;
         private Integer requestedBreakMinutes;
         private String requestedMemo;
@@ -103,9 +116,17 @@ public class CorrectionRequestDto {
         private RequestType type;
         private Long workRecordId;
         private LocalDate workDate;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime originalStartTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime originalEndTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime requestedStartTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime requestedEndTime;
         private CorrectionStatus status;
         private RequesterInfo requester;

--- a/src/main/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDto.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDto.java
@@ -2,6 +2,8 @@ package com.example.paycheck.domain.workrecord.dto;
 
 import com.example.paycheck.domain.workrecord.entity.WorkRecord;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
@@ -29,7 +31,11 @@ public class WorkRecordDto {
         private Long id;
         private Long contractId;
         private LocalDate workDate;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime startTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime endTime;
         private Integer breakMinutes;
         private Integer totalWorkMinutes;
@@ -63,7 +69,11 @@ public class WorkRecordDto {
         private String workerCode;
         private String workplaceName;
         private LocalDate workDate;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime startTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime endTime;
         private Integer breakMinutes;
         private Integer totalWorkMinutes;
@@ -101,7 +111,11 @@ public class WorkRecordDto {
         private String workerName;
         private String workplaceName;
         private LocalDate workDate;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime startTime;
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime endTime;
         private Integer breakMinutes;
         private BigDecimal hourlyWage;
@@ -136,9 +150,13 @@ public class WorkRecordDto {
         private LocalDate workDate;
 
         @NotNull(message = "시작 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime startTime;
 
         @NotNull(message = "종료 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime endTime;
 
         @Min(value = 0, message = "휴게 시간은 0분 이상이어야 합니다.")
@@ -147,6 +165,8 @@ public class WorkRecordDto {
         @Size(max = 500, message = "메모는 500자 이하로 입력해주세요.")
         private String memo;
 
+        @JsonIgnore
+        @Schema(hidden = true)
         @AssertTrue(message = "종료 시간은 시작 시간과 달라야 합니다.")
         public boolean isValidTimeRange() {
             if (startTime == null || endTime == null) return true; // null 체크는 @NotNull이 담당
@@ -167,9 +187,13 @@ public class WorkRecordDto {
         private List<LocalDate> workDates;
 
         @NotNull(message = "시작 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime startTime;
 
         @NotNull(message = "종료 시간은 필수입니다.")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime endTime;
 
         @Min(value = 0, message = "휴게 시간은 0분 이상이어야 합니다.")
@@ -178,6 +202,8 @@ public class WorkRecordDto {
         @Size(max = 500, message = "메모는 500자 이하로 입력해주세요.")
         private String memo;
 
+        @JsonIgnore
+        @Schema(hidden = true)
         @AssertTrue(message = "종료 시간은 시작 시간과 달라야 합니다.")
         public boolean isValidTimeRange() {
             if (startTime == null || endTime == null) return true; // null 체크는 @NotNull이 담당
@@ -191,8 +217,12 @@ public class WorkRecordDto {
     @AllArgsConstructor
     @Schema(name = "WorkRecordUpdateRequest")
     public static class UpdateRequest {
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "09:00")
         private LocalTime startTime;
 
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "18:00")
         private LocalTime endTime;
 
         @Min(value = 0, message = "휴게 시간은 0분 이상이어야 합니다.")
@@ -201,6 +231,8 @@ public class WorkRecordDto {
         @Size(max = 500, message = "메모는 500자 이하로 입력해주세요.")
         private String memo;
 
+        @JsonIgnore
+        @Schema(hidden = true)
         @AssertTrue(message = "종료 시간은 시작 시간과 달라야 합니다.")
         public boolean isValidTimeRange() {
             if (startTime == null || endTime == null) return true; // null 허용 필드이므로 검증 생략


### PR DESCRIPTION
## 📝 변경 사항

### 주요 변경 내용
- WorkRecord/CorrectionRequest DTO의 LocalTime 필드를 Swagger에서 문자열로 표시되도록 코드 수정하였습니다.

### 상세 설명
- Swagger가 LocalTime을 객체로 노출해 실제 요청이 MismatchedInputException으로 실패하여 요청/응답 포맷을 일관된 문자열 형식으로 제공하도록 수정하였습니다.

## ✅ 체크리스트
<!-- PR을 제출하기 전에 아래 항목을 확인해주세요 -->
- [x] PR 제목이 형식에 맞는가? (유형: 작업 요약)
- [x] 코드가 정상적으로 빌드되는가?
- [x] 새로운 기능에 대한 테스트 코드를 작성했는가?
- [x] 모든 테스트가 통과하는가?
- [x] 코드 스타일 가이드를 따랐는가?
- [x] 관련 문서를 업데이트했는가?

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 응답의 시간 필드에 대한 문서화 개선으로 형식 및 예제가 명확하게 표시됩니다.
  * 시간 데이터가 일관된 HH:mm 형식으로 반환되도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->