### PR TITLE
chore: 회원가입 name 필드 추가

### DIFF
--- a/src/main/java/com/example/paycheck/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/example/paycheck/domain/auth/dto/AuthDto.java
@@ -43,6 +43,9 @@ public class AuthDto {
         @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
         private String kakaoAccessToken;
 
+        @NotBlank(message = "이름은 필수입니다.")
+        private String name;
+
         @NotBlank(message = "사용자 유형은 필수입니다.")
         private String userType;
 

--- a/src/main/java/com/example/paycheck/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/paycheck/domain/auth/service/AuthService.java
@@ -159,7 +159,7 @@ public class AuthService {
         // 회원가입 요청 DTO 생성
         UserDto.RegisterRequest registerRequest = UserDto.RegisterRequest.builder()
                 .kakaoId(userInfo.kakaoId())
-                .name(oAuthService.resolveDisplayName(userInfo))
+                .name(request.getName().trim())
                 .phone(request.getPhone())
                 .userType(userType)
                 .profileImageUrl(request.getProfileImageUrl())

--- a/src/test/java/com/example/paycheck/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/auth/service/AuthServiceTest.java
@@ -127,6 +127,7 @@ class AuthServiceTest {
         // given
         AuthDto.KakaoRegisterRequest request = AuthDto.KakaoRegisterRequest.builder()
                 .kakaoAccessToken("kakao_access_token")
+                .name("홍길동")
                 .phone("010-1234-5678")
                 .userType("WORKER")
                 .profileImageUrl("https://example.com/profile.jpg")
@@ -143,7 +144,6 @@ class AuthServiceTest {
 
         when(oAuthService.getKakaoUserInfo(request.getKakaoAccessToken())).thenReturn(kakaoUserInfo);
         when(userRepository.findByKakaoId(kakaoUserInfo.kakaoId())).thenReturn(Optional.empty());
-        when(oAuthService.resolveDisplayName(kakaoUserInfo)).thenReturn("카카오 닉네임");
         when(userService.register(any(UserDto.RegisterRequest.class))).thenReturn(registerResponse);
         when(tokenService.generateTokenPair(1L)).thenReturn(tokenPair);
 
@@ -169,6 +169,7 @@ class AuthServiceTest {
         // given
         AuthDto.KakaoRegisterRequest request = AuthDto.KakaoRegisterRequest.builder()
                 .kakaoAccessToken("kakao_access_token")
+                .name("홍길동")
                 .phone("010-1234-5678")
                 .userType("WORKER")
                 .bankName("카카오뱅크")
@@ -193,6 +194,7 @@ class AuthServiceTest {
         // given
         AuthDto.KakaoRegisterRequest request = AuthDto.KakaoRegisterRequest.builder()
                 .kakaoAccessToken("kakao_access_token")
+                .name("홍길동")
                 .phone("010-1234-5678")
                 .userType("WORKER")
                 .bankName(null) // 은행 정보 없음
@@ -216,6 +218,7 @@ class AuthServiceTest {
         // given
         AuthDto.KakaoRegisterRequest request = AuthDto.KakaoRegisterRequest.builder()
                 .kakaoAccessToken("kakao_access_token")
+                .name("고용주")
                 .phone("010-9876-5432")
                 .userType("EMPLOYER")
                 .profileImageUrl("https://example.com/profile.jpg")
@@ -229,7 +232,6 @@ class AuthServiceTest {
 
         when(oAuthService.getKakaoUserInfo(request.getKakaoAccessToken())).thenReturn(kakaoUserInfo);
         when(userRepository.findByKakaoId(kakaoUserInfo.kakaoId())).thenReturn(Optional.empty());
-        when(oAuthService.resolveDisplayName(kakaoUserInfo)).thenReturn("카카오 닉네임");
         when(userService.register(any(UserDto.RegisterRequest.class))).thenReturn(registerResponse);
         when(tokenService.generateTokenPair(2L)).thenReturn(tokenPair);
 
@@ -342,6 +344,7 @@ class AuthServiceTest {
         // given
         AuthDto.KakaoRegisterRequest request = AuthDto.KakaoRegisterRequest.builder()
                 .kakaoAccessToken("kakao_access_token")
+                .name("홍길동")
                 .phone("010-1234-5678")
                 .userType("INVALID_TYPE")
                 .build();


### PR DESCRIPTION
## 📝 변경 사항

### 주요 변경 내용
- POST /api/auth/kakao/register 요청 DTO에 name 필드 추가
- 회원가입 시 사용자 이름을 카카오 프로필 닉네임이 아니라 요청값으로 저장하도록 변경

### 상세 설명
- 회원가입 정책이 “이름을 별도 입력받는다”로 바뀌어서, 백엔드도 동일하게 반영했습니다.
- `AuthDto.KakaoRegisterRequest`에` @NotBlank` 검증이 걸린 `name`을 추가해 필수 입력으로 강제했습니다.
- `AuthService.registerWithKakao()`에서 기존 `oAuthService.resolveDisplayName(userInfo)` 사용을 제거하고, `request.getName().trim()`을 사용하도록 변경했습니다.
- 이에 맞춰 `AuthServiceTest`의 회원가입 관련 케이스들에 [.name(...)]을 추가하고, 기존 닉네임 해석 mocking 코드를 정리했습니다

## ✅ 체크리스트
<!-- PR을 제출하기 전에 아래 항목을 확인해주세요 -->
- [x] PR 제목이 형식에 맞는가? (유형: 작업 요약)
- [x] 코드가 정상적으로 빌드되는가?
- [x] 새로운 기능에 대한 테스트 코드를 작성했는가?
- [x] 모든 테스트가 통과하는가?
- [x] 코드 스타일 가이드를 따랐는가?
- [x] 관련 문서를 업데이트했는가?

## 🔗 관련 PR
<!-- 관련된 다른 PR이 있다면 링크해주세요 -->
- Related to #

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 카카오 회원가입 시 이름 필드가 필수 입력 항목으로 추가되었습니다.

* **Tests**
  * 카카오 회원가입 관련 테스트 케이스가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->