### PR TITLE
fix(notification): 읽지 않은 알림 개수 조회 응답 형식 수정

### DIFF
--- a/src/main/java/com/example/paycheck/api/notification/NotificationController.java
+++ b/src/main/java/com/example/paycheck/api/notification/NotificationController.java
@@ -2,6 +2,7 @@ package com.example.paycheck.api.notification;
 
 import com.example.paycheck.common.dto.ApiResponse;
 import com.example.paycheck.domain.notification.dto.NotificationPageResponse;
+import com.example.paycheck.domain.notification.dto.UnreadCountResponse;
 import com.example.paycheck.domain.notification.service.NotificationService;
 import com.example.paycheck.domain.notification.service.SseEmitterService;
 import com.example.paycheck.domain.user.entity.User;
@@ -50,8 +51,9 @@ public class NotificationController {
 
     @Operation(summary = "읽지 않은 알림 개수 조회", description = "로그인한 사용자의 읽지 않은 알림 개수를 조회합니다.")
     @GetMapping("/unread-count")
-    public ApiResponse<Long> getUnreadCount(@AuthenticationPrincipal User user) {
-        return ApiResponse.success(notificationService.getUnreadCount(user));
+    public ApiResponse<UnreadCountResponse> getUnreadCount(@AuthenticationPrincipal User user) {
+        long count = notificationService.getUnreadCount(user);
+        return ApiResponse.success(new UnreadCountResponse(count));
     }
 
     @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")

--- a/src/main/java/com/example/paycheck/domain/notification/dto/UnreadCountResponse.java
+++ b/src/main/java/com/example/paycheck/domain/notification/dto/UnreadCountResponse.java
@@ -1,0 +1,10 @@
+package com.example.paycheck.domain.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UnreadCountResponse {
+    private long count;
+}

--- a/src/test/java/com/example/paycheck/api/notification/NotificationControllerTest.java
+++ b/src/test/java/com/example/paycheck/api/notification/NotificationControllerTest.java
@@ -1,0 +1,63 @@
+package com.example.paycheck.api.notification;
+
+import com.example.paycheck.domain.notification.service.NotificationService;
+import com.example.paycheck.domain.notification.service.SseEmitterService;
+import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.user.enums.UserType;
+import com.example.paycheck.global.security.JwtAuthenticationFilter;
+import com.example.paycheck.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("NotificationController 테스트")
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private SseEmitterService sseEmitterService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    @DisplayName("읽지 않은 알림 개수 조회 - 응답 포맷 검증")
+    void getUnreadCount_ResponseFormat() throws Exception {
+        // given
+        given(notificationService.getUnreadCount(any(User.class))).willReturn(5L);
+
+        User testUser = User.builder()
+                .id(1L)
+                .kakaoId("12345")
+                .name("테스트")
+                .userType(UserType.WORKER)
+                .build();
+
+        // when & then
+        mockMvc.perform(get("/api/notifications/unread-count")
+                        .requestAttr("user", testUser))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.count").value(5));
+    }
+}

--- a/src/test/java/com/example/paycheck/api/notification/NotificationControllerTest.java
+++ b/src/test/java/com/example/paycheck/api/notification/NotificationControllerTest.java
@@ -6,11 +6,14 @@ import com.example.paycheck.domain.user.entity.User;
 import com.example.paycheck.domain.user.enums.UserType;
 import com.example.paycheck.global.security.JwtAuthenticationFilter;
 import com.example.paycheck.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -40,22 +43,30 @@ class NotificationControllerTest {
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Test
-    @DisplayName("읽지 않은 알림 개수 조회 - 응답 포맷 검증")
-    void getUnreadCount_ResponseFormat() throws Exception {
-        // given
-        given(notificationService.getUnreadCount(any(User.class))).willReturn(5L);
+    private User testUser;
 
-        User testUser = User.builder()
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
                 .id(1L)
                 .kakaoId("12345")
                 .name("테스트")
                 .userType(UserType.WORKER)
                 .build();
 
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(testUser, null, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림 개수 조회 - 응답 포맷 검증")
+    void 읽지_않은_알림_개수_조회() throws Exception {
+        // given
+        given(notificationService.getUnreadCount(any(User.class))).willReturn(5L);
+
         // when & then
-        mockMvc.perform(get("/api/notifications/unread-count")
-                        .requestAttr("user", testUser))
+        mockMvc.perform(get("/api/notifications/unread-count"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.count").value(5));


### PR DESCRIPTION
## 문제 설명
Closes #160

GET `/api/notifications/unread-count` 엔드포인트가 `Long` 값을 직접 반환하여 모바일 클라이언트에서 `data.count` 형태로 접근할 수 없었습니다.

## 변경 사항
- `UnreadCountResponse` DTO 추가 (`count` 필드 포함)
- `NotificationController.getUnreadCount()` 반환 타입을 `ApiResponse<Long>` → `ApiResponse<UnreadCountResponse>` 변경
- JSON 응답 형식 검증 테스트 추가

## 응답 형식 변경
**Before:**
```json
{ "success": true, "data": 5 }
```

**After:**
```json
{ "success": true, "data": { "count": 5 } }
```

## 테스트
- `NotificationControllerTest.getUnreadCount_ResponseFormat()` 추가
- `$.data.count` JSON 경로 검증


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 읽지 않은 알림 개수 조회 엔드포인트의 응답 구조를 개선했습니다.

* **Tests**
  * 알림 조회 기능에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->