### PR TITLE
[fix] 회원탈퇴 시 소프트 삭제가 DB에 반영되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/example/paycheck/domain/user/entity/User.java
+++ b/src/main/java/com/example/paycheck/domain/user/entity/User.java
@@ -38,6 +38,9 @@ public class User extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Version
+    private Long version;
+
     public void updateProfile(String name, String phone, String profileImageUrl) {
         if (name != null) this.name = name;
         if (phone != null) this.phone = phone;

--- a/src/main/java/com/example/paycheck/domain/user/service/UserWithdrawService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserWithdrawService.java
@@ -55,24 +55,24 @@ public class UserWithdrawService {
      * 회원 탈퇴 처리
      */
     public void withdraw(User user) {
-        if (user.isDeleted()) {
+        // managed 엔티티를 먼저 로드하여 DB 기준으로 검증/처리 수행
+        User managedUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        if (managedUser.isDeleted()) {
             throw new BadRequestException(ErrorCode.USER_ALREADY_DELETED, "이미 탈퇴한 사용자입니다.");
         }
 
-        if (user.getUserType() == UserType.EMPLOYER) {
-            withdrawEmployer(user);
+        if (managedUser.getUserType() == UserType.EMPLOYER) {
+            withdrawEmployer(managedUser);
         } else {
-            withdrawWorker(user);
+            withdrawWorker(managedUser);
         }
 
-        cleanupCommonData(user);
-
-        // detached 엔티티를 managed 엔티티로 다시 로드하여 변경사항이 DB에 반영되도록 함
-        User managedUser = userRepository.findById(user.getId())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        cleanupCommonData(managedUser);
         managedUser.withdraw();
 
-        log.info("회원 탈퇴 완료: userId={}, userType={}", user.getId(), user.getUserType());
+        log.info("회원 탈퇴 완료: userId={}, userType={}", managedUser.getId(), managedUser.getUserType());
     }
 
     /**

--- a/src/main/java/com/example/paycheck/domain/user/service/UserWithdrawService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserWithdrawService.java
@@ -2,6 +2,7 @@ package com.example.paycheck.domain.user.service;
 
 import com.example.paycheck.common.exception.BadRequestException;
 import com.example.paycheck.common.exception.ErrorCode;
+import com.example.paycheck.common.exception.NotFoundException;
 import com.example.paycheck.domain.allowance.repository.WeeklyAllowanceRepository;
 import com.example.paycheck.domain.allowance.service.WeeklyAllowanceService;
 import com.example.paycheck.domain.auth.repository.RefreshTokenRepository;
@@ -14,6 +15,7 @@ import com.example.paycheck.domain.notification.repository.NotificationRepositor
 import com.example.paycheck.domain.settings.repository.UserSettingsRepository;
 import com.example.paycheck.domain.user.entity.User;
 import com.example.paycheck.domain.user.enums.UserType;
+import com.example.paycheck.domain.user.repository.UserRepository;
 import com.example.paycheck.domain.worker.entity.Worker;
 import com.example.paycheck.domain.worker.repository.WorkerRepository;
 import com.example.paycheck.domain.workplace.entity.Workplace;
@@ -47,6 +49,7 @@ public class UserWithdrawService {
     private final FcmTokenRepository fcmTokenRepository;
     private final NotificationRepository notificationRepository;
     private final UserSettingsRepository userSettingsRepository;
+    private final UserRepository userRepository;
 
     /**
      * 회원 탈퇴 처리
@@ -63,7 +66,11 @@ public class UserWithdrawService {
         }
 
         cleanupCommonData(user);
-        user.withdraw();
+
+        // detached 엔티티를 managed 엔티티로 다시 로드하여 변경사항이 DB에 반영되도록 함
+        User managedUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        managedUser.withdraw();
 
         log.info("회원 탈퇴 완료: userId={}, userType={}", user.getId(), user.getUserType());
     }

--- a/src/test/java/com/example/paycheck/domain/user/service/UserWithdrawServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserWithdrawServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.paycheck.domain.user.service;
 
 import com.example.paycheck.common.exception.BadRequestException;
+import com.example.paycheck.common.exception.NotFoundException;
 import com.example.paycheck.domain.auth.repository.RefreshTokenRepository;
 import com.example.paycheck.domain.contract.entity.WorkerContract;
 import com.example.paycheck.domain.contract.repository.WorkerContractRepository;
@@ -185,7 +186,14 @@ class UserWithdrawServiceTest {
     @DisplayName("이미 탈퇴한 사용자 재탈퇴 시 예외 발생")
     void withdraw_alreadyDeleted_throwsException() {
         // given
-        employer.withdraw();
+        User deletedEmployer = User.builder()
+                .id(1L)
+                .kakaoId("kakao_employer")
+                .name("고용주")
+                .userType(UserType.EMPLOYER)
+                .build();
+        deletedEmployer.withdraw();
+        when(userRepository.findById(employer.getId())).thenReturn(Optional.of(deletedEmployer));
 
         // when & then
         assertThatThrownBy(() -> userWithdrawService.withdraw(employer))
@@ -254,5 +262,17 @@ class UserWithdrawServiceTest {
         // COMPLETED 상태로의 업데이트는 호출되지 않음
         verify(workRecordRepository, never()).bulkUpdateStatusByContractIdAndStatus(
                 any(), eq(WorkRecordStatus.COMPLETED), any());
+    }
+
+    @Test
+    @DisplayName("findById 결과가 비어있을 때 NotFoundException 발생")
+    void withdraw_userNotFound_throwsNotFoundException() {
+        // given
+        when(userRepository.findById(employer.getId())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userWithdrawService.withdraw(employer))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("사용자를 찾을 수 없습니다");
     }
 }

--- a/src/test/java/com/example/paycheck/domain/user/service/UserWithdrawServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserWithdrawServiceTest.java
@@ -12,6 +12,7 @@ import com.example.paycheck.domain.allowance.repository.WeeklyAllowanceRepositor
 import com.example.paycheck.domain.allowance.service.WeeklyAllowanceService;
 import com.example.paycheck.domain.settings.repository.UserSettingsRepository;
 import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.user.repository.UserRepository;
 import com.example.paycheck.domain.user.enums.UserType;
 import com.example.paycheck.domain.worker.entity.Worker;
 import com.example.paycheck.domain.worker.repository.WorkerRepository;
@@ -65,6 +66,8 @@ class UserWithdrawServiceTest {
     private WeeklyAllowanceRepository weeklyAllowanceRepository;
     @Mock
     private WorkRecordCoordinatorService workRecordCoordinatorService;
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private UserWithdrawService userWithdrawService;
@@ -118,6 +121,7 @@ class UserWithdrawServiceTest {
         when(workRecordRepository.bulkUpdateStatusByContractIdAndStatus(
                 eq(contract.getId()), eq(WorkRecordStatus.SCHEDULED), eq(WorkRecordStatus.DELETED)))
                 .thenReturn(3);
+        when(userRepository.findById(employer.getId())).thenReturn(Optional.of(employer));
 
         // when
         userWithdrawService.withdraw(employer);
@@ -160,6 +164,7 @@ class UserWithdrawServiceTest {
         when(workerRepository.findByUserId(worker.getId())).thenReturn(Optional.of(workerEntity));
         when(workerContractRepository.findByWorkerId(workerEntity.getId()))
                 .thenReturn(List.of(activeContract, inactiveContract));
+        when(userRepository.findById(worker.getId())).thenReturn(Optional.of(worker));
 
         // when
         userWithdrawService.withdraw(worker);
@@ -192,6 +197,7 @@ class UserWithdrawServiceTest {
     void withdraw_cleanupsCommonData() {
         // given
         when(workerRepository.findByUserId(worker.getId())).thenReturn(Optional.empty());
+        when(userRepository.findById(worker.getId())).thenReturn(Optional.of(worker));
 
         // when
         userWithdrawService.withdraw(worker);
@@ -208,6 +214,7 @@ class UserWithdrawServiceTest {
     void withdraw_noProfile_noException() {
         // given
         when(employerRepository.findByUserId(employer.getId())).thenReturn(Optional.empty());
+        when(userRepository.findById(employer.getId())).thenReturn(Optional.of(employer));
 
         // when
         userWithdrawService.withdraw(employer);
@@ -236,6 +243,7 @@ class UserWithdrawServiceTest {
 
         when(workerRepository.findByUserId(worker.getId())).thenReturn(Optional.of(workerEntity));
         when(workerContractRepository.findByWorkerId(workerEntity.getId())).thenReturn(List.of(contract));
+        when(userRepository.findById(worker.getId())).thenReturn(Optional.of(worker));
 
         // when
         userWithdrawService.withdraw(worker);


### PR DESCRIPTION
## 🔖 관련 GitHub Issue
- Closes #130

## 📝 변경 사항

### 주요 변경 내용
- 회원탈퇴 시 detached 엔티티로 인해 deletedAt이 DB에 반영되지 않는 버그 수정
- User 엔티티에 @Version 필드 추가 (Optimistic Locking)
- UserWithdrawService.withdraw()에서 managed 엔티티를 다시 로드하도록 변경
- 예외 타입 개선: BadRequestException → NotFoundException

### 상세 설명
**문제 원인:**
AuthController.withdraw()에서 @AuthenticationPrincipal로 주입받은 User 엔티티는 JwtAuthenticationFilter에서 로드된 **detached 엔티티**입니다. UserWithdrawService.withdraw() 트랜잭션 내에서 user.withdraw()를 호출해도 해당 엔티티가 영속성 컨텍스트에 관리되지 않아 변경사항이 DB에 flush되지 않았습니다.

**해결 방법:**
1. userRepository.findById()로 managed 엔티티를 다시 로드한 뒤 withdraw() 호출
2. @Version 필드 추가로 동시 탈퇴 요청(Race Condition) 방지
3. 사용자 없음 예외를 NotFoundException으로 변경하여 더 적절한 HTTP 상태 코드 반환

## ✅ 체크리스트
- [x] PR 제목이 형식에 맞는가? (유형: 작업 요약)
- [x] 코드가 정상적으로 빌드되는가?
- [x] 새로운 기능에 대한 테스트 코드를 작성했는가?
- [x] 모든 테스트가 통과하는가?
- [x] 코드 스타일 가이드를 따랐는가?
- [x] 관련 문서를 업데이트했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 동시성 환경에서 데이터 충돌 감지 및 보호를 위해 버전 기반 검증을 도입했습니다.
  * 출금 처리 흐름의 데이터 일관성 및 예외(사용자 미존재) 처리를 강화해 오류 상황 대응을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->