### PR TITLE
[feat] 프로필 이미지 업로드 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'software.amazon.awssdk:s3:2.25.67'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'

--- a/docs/API_SPECIFICATION.md
+++ b/docs/API_SPECIFICATION.md
@@ -4,68 +4,69 @@
 
 | 인덱스 | 기능 | Method | API Path | 설명 | FE 개발 현황 | BE 개발 현황 | 수정일 | JSON Example |
 |--------|------|--------|----------|------|--------------|--------------|--------|--------------|
-| **1. 인증 API** ||||||||
+| **1. 인증 API** |  |  |  |  |  |  |  |  |
 | 1.1 | 카카오 로그인 | POST | `/api/auth/kakao/login` | 카카오 소셜 로그인 (신규 사용자 자동 등록) | 대기 | 대기 | - | [링크](#11-카카오-로그인) |
 | 1.2 | 로그아웃 | POST | `/api/auth/logout` | 로그아웃 및 토큰 무효화 | 대기 | 대기 | - | [링크](#12-로그아웃) |
 | 1.3 | 토큰 갱신 | POST | `/api/auth/refresh` | Access Token 갱신 | 대기 | 대기 | - | [링크](#13-토큰-갱신) |
 | 1.4 | 회원 탈퇴 | DELETE | `/api/auth/withdraw` | 회원 탈퇴 및 카카오 연결 해제 | 대기 | 완료 | 2026-03-11 | [링크](#14-회원-탈퇴) |
-| **2. 사용자 API** ||||||||
+| **2. 사용자 API** |  |  |  |  |  |  |  |  |
 | 2.1 | 내 정보 조회 | GET | `/api/users/me` | 로그인한 사용자 정보 | 대기 | 대기 | - | [링크](#21-내-정보-조회) |
 | 2.2 | 내 정보 수정 | PUT | `/api/users/me` | 사용자 정보 수정 | 대기 | 대기 | - | [링크](#22-내-정보-수정) |
-| 2.3 | 계좌 정보 수정 | PUT | `/api/users/me/account` | 근로자 계좌 정보 수정 | 대기 | 대기 | - | [링크](#23-계좌-정보-수정) |
-| **3. 고용주 - 사업장** ||||||||
+| 2.3 | 프로필 이미지 업로드 | POST | `/api/users/me/profile-image` | 프로필 이미지 업로드 후 URL 반환 | 대기 | 완료 | - | [링크](#23-프로필-이미지-업로드) |
+| 2.4 | 계좌 정보 수정 | PUT | `/api/users/me/account` | 근로자 계좌 정보 수정 | 대기 | 대기 | - | [링크](#24-계좌-정보-수정) |
+| **3. 고용주 - 사업장** |  |  |  |  |  |  |  |  |
 | 3.1 | 사업장 등록 | POST | `/api/employer/workplaces` | 새 사업장 등록 | 대기 | 대기 | - | [링크](#31-사업장-등록) |
 | 3.2 | 사업장 목록 | GET | `/api/employer/workplaces` | 내 사업장 목록 조회 | 대기 | 대기 | - | [링크](#32-사업장-목록) |
 | 3.3 | 사업장 상세 | GET | `/api/employer/workplaces/{id}` | 사업장 상세 정보 | 대기 | 대기 | - | [링크](#33-사업장-상세) |
 | 3.4 | 사업장 수정 | PUT | `/api/employer/workplaces/{id}` | 사업장 정보 수정 | 대기 | 대기 | - | [링크](#34-사업장-수정) |
 | 3.5 | 사업장 비활성화 | DELETE | `/api/employer/workplaces/{id}` | 사업장 비활성화 | 대기 | 대기 | - | [링크](#35-사업장-비활성화) |
-| **4. 고용주 - 근로자** ||||||||
+| **4. 고용주 - 근로자** |  |  |  |  |  |  |  |  |
 | 4.1 | 근로자 추가 | POST | `/api/employer/workplaces/{workplace_id}/workers` | 코드로 근로자 추가 | 대기 | 대기 | - | [링크](#41-근로자-추가) |
 | 4.2 | 근로자 목록 | GET | `/api/employer/workplaces/{workplace_id}/workers` | 사업장 근로자 목록 | 대기 | 대기 | - | [링크](#42-근로자-목록) |
 | 4.3 | 계약 상세 | GET | `/api/employer/contracts/{id}` | 계약 상세 정보 | 대기 | 대기 | - | [링크](#43-계약-상세) |
 | 4.4 | 계약 수정 | PUT | `/api/employer/contracts/{id}` | 계약 정보 수정 | 대기 | 대기 | - | [링크](#44-계약-수정) |
 | 4.5 | 계약 종료 | DELETE | `/api/employer/contracts/{id}` | 계약 종료 | 대기 | 대기 | - | [링크](#45-계약-종료) |
-| **5. 고용주 - 근무일정** ||||||||
+| **5. 고용주 - 근무일정** |  |  |  |  |  |  |  |  |
 | 5.1 | 일정 등록 | POST | `/api/employer/work-records` | 근무 일정 등록 | 대기 | 대기 | - | [링크](#51-일정-등록) |
 | 5.2 | 일정 일괄등록 | POST | `/api/employer/work-records/batch` | 여러 일정 일괄 등록 | 대기 | 대기 | - | [링크](#52-일정-일괄등록) |
 | 5.3 | 근무기록 조회 | GET | `/api/employer/work-records` | 캘린더 근무 기록 조회 | 대기 | 대기 | - | [링크](#53-근무기록-조회) |
 | 5.4 | 일정 수정 | PUT | `/api/employer/work-records/{id}` | 근무 시간 수정 | 대기 | 대기 | - | [링크](#54-일정-수정) |
 | 5.5 | 근무 완료 | PUT | `/api/employer/work-records/{id}/complete` | 근무 완료 처리 | 대기 | 대기 | - | [링크](#55-근무-완료) |
 | 5.6 | 일정 삭제 | DELETE | `/api/employer/work-records/{id}` | 근무 일정 삭제 | 대기 | 대기 | - | [링크](#56-일정-삭제) |
-| **6. 고용주 - 정정요청** ||||||||
+| **6. 고용주 - 정정요청** |  |  |  |  |  |  |  |  |
 | 6.1 | 요청 목록 | GET | `/api/employer/correction-requests` | 정정 요청 목록 | 대기 | 대기 | - | [링크](#61-요청-목록) |
 | 6.2 | 요청 상세 | GET | `/api/employer/correction-requests/{id}` | 정정 요청 상세 | 대기 | 대기 | - | [링크](#62-요청-상세) |
 | 6.3 | 요청 승인 | PUT | `/api/employer/correction-requests/{id}/approve` | 정정 요청 승인 | 대기 | 대기 | - | [링크](#63-요청-승인) |
 | 6.4 | 요청 반려 | PUT | `/api/employer/correction-requests/{id}/reject` | 정정 요청 반려 | 대기 | 대기 | - | [링크](#64-요청-반려) |
-| **7. 고용주 - 급여** ||||||||
+| **7. 고용주 - 급여** |  |  |  |  |  |  |  |  |
 | 7.1 | 급여 목록 | GET | `/api/employer/salaries` | 월별 급여 목록 | 대기 | 대기 | - | [링크](#71-급여-목록) |
 | 7.2 | 급여 상세 | GET | `/api/employer/salaries/{id}` | 급여 상세 정보 | 대기 | 대기 | - | [링크](#72-급여-상세) |
 | 7.3 | 급여 계산 | POST | `/api/employer/salaries/calculate` | 급여 계산 | 대기 | 대기 | - | [링크](#73-급여-계산) |
 | 7.4 | 급여 송금 | POST | `/api/employer/payments` | 급여 송금 처리 | 대기 | 대기 | - | [링크](#74-급여-송금) |
-| **8. 근로자 - 근무일정** ||||||||
+| **8. 근로자 - 근무일정** |  |  |  |  |  |  |  |  |
 | 8.1 | 일정 조회 | GET | `/api/worker/work-records` | 월별 근무 일정 조회 | 대기 | 대기 | - | [링크](#81-일정-조회) |
 | 8.2 | 기록 상세 | GET | `/api/worker/work-records/{id}` | 근무 기록 상세 | 대기 | 대기 | - | [링크](#82-기록-상세) |
 | 8.3 | 근무 완료 | PUT | `/api/worker/work-records/{id}/complete` | 근무 완료 처리 | 대기 | 대기 | - | [링크](#83-근무-완료) |
-| **9. 근로자 - 정정요청** ||||||||
+| **9. 근로자 - 정정요청** |  |  |  |  |  |  |  |  |
 | 9.1 | 요청 생성 | POST | `/api/worker/correction-requests` | 정정 요청 생성 | 대기 | 대기 | - | [링크](#91-요청-생성) |
 | 9.2 | 내 요청 목록 | GET | `/api/worker/correction-requests` | 내 정정 요청 목록 | 대기 | 대기 | - | [링크](#92-내-요청-목록) |
 | 9.3 | 요청 상세 | GET | `/api/worker/correction-requests/{id}` | 내 정정 요청 상세 조회 | 대기 | 대기 | - | [링크](#93-요청-상세) |
 | 9.4 | 요청 취소 | DELETE | `/api/worker/correction-requests/{id}` | 정정 요청 취소 | 대기 | 대기 | - | [링크](#94-요청-취소) |
-| **10. 근로자 - 급여** ||||||||
+| **10. 근로자 - 급여** |  |  |  |  |  |  |  |  |
 | 10.1 | 급여 목록 | GET | `/api/worker/salaries` | 연도별 급여 목록 | 대기 | 대기 | - | [링크](#101-급여-목록) |
 | 10.2 | 급여 상세 | GET | `/api/worker/salaries/{id}` | 급여 상세 정보 | 대기 | 대기 | - | [링크](#102-급여-상세) |
 | 10.3 | 송금 내역 | GET | `/api/worker/payments` | 송금 내역 조회 | 대기 | 대기 | - | [링크](#103-송금-내역) |
-| **11. 공통 - 알림** ||||||||
+| **11. 공통 - 알림** |  |  |  |  |  |  |  |  |
 | 11.1 | 알림 목록 | GET | `/api/notifications` | 알림 목록 조회 | 대기 | 대기 | - | [링크](#111-알림-목록) |
 | 11.2 | SSE 알림 구독 | GET | `/api/notifications/stream` | 실시간 알림 구독 (SSE) | 대기 | 대기 | - | [링크](#112-sse-알림-구독) |
 | 11.3 | 읽지 않은 알림 개수 | GET | `/api/notifications/unread-count` | 읽지 않은 알림 개수 조회 | 대기 | 대기 | - | [링크](#113-읽지-않은-알림-개수) |
 | 11.4 | 알림 읽음 | PUT | `/api/notifications/{id}/read` | 알림 읽음 처리 | 대기 | 대기 | - | [링크](#114-알림-읽음) |
 | 11.5 | 전체 읽음 | PUT | `/api/notifications/read-all` | 모든 알림 읽음 | 대기 | 대기 | - | [링크](#115-전체-읽음) |
 | 11.6 | 알림 삭제 | DELETE | `/api/notifications/{id}` | 알림 삭제 | 대기 | 대기 | - | [링크](#116-알림-삭제) |
-| **12. 공통 - 설정** ||||||||
+| **12. 공통 - 설정** |  |  |  |  |  |  |  |  |
 | 12.1 | 내 설정 조회 | GET | `/api/settings/me` | 로그인한 사용자의 알림 설정 조회 | 대기 | 완료 | 2025-12-10 | [링크](#121-내-설정-조회) |
 | 12.2 | 내 설정 수정 | PUT | `/api/settings/me` | 로그인한 사용자의 알림 설정 수정 | 대기 | 완료 | 2025-12-10 | [링크](#122-내-설정-수정) |
-| **13. 공통 - 공지사항** |||||||||
+| **13. 공통 - 공지사항** |  |  |  |  |  |  |  |  |
 | 13.1 | 공지사항 작성 | POST | `/api/workplaces/{workplaceId}/notices` | 사업장 공지사항 작성 (사업장 소속 인원) | 대기 | 완료 | 2026-02-21 | [링크](#131-공지사항-작성) |
 | 13.2 | 공지사항 목록 조회 | GET | `/api/workplaces/{workplaceId}/notices` | 사업장 공지사항 목록 조회 (만료 제외) | 대기 | 완료 | 2026-02-21 | [링크](#132-공지사항-목록-조회) |
 | 13.3 | 공지사항 단건 조회 | GET | `/api/notices/{noticeId}` | 공지사항 상세 조회 | 대기 | 완료 | 2026-02-21 | [링크](#133-공지사항-단건-조회) |
@@ -242,7 +243,40 @@
 
 ---
 
-### 2.3 계좌 정보 수정
+### 2.3 프로필 이미지 업로드
+
+**Request:**
+- Method: `POST`
+- URL: `/api/users/me/profile-image`
+- Header: `Authorization: Bearer {accessToken}`
+- Content-Type: `multipart/form-data`
+- Body:
+  - `file`: JPG, PNG, GIF, WEBP, HEIC 이미지 파일
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "profileImageUrl": "https://paycheck-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1001/550e8400-e29b-41d4-a716-446655440000.png"
+  }
+}
+```
+
+**Error (잘못된 파일 형식):**
+```json
+{
+  "success": false,
+  "error": {
+    "code": "INVALID_PROFILE_IMAGE_FILE",
+    "message": "프로필 이미지는 JPG, PNG, GIF, WEBP, HEIC 형식만 업로드할 수 있습니다."
+  }
+}
+```
+
+---
+
+### 2.4 계좌 정보 수정
 
 **Request:**
 ```json

--- a/src/main/java/com/example/paycheck/api/user/UserController.java
+++ b/src/main/java/com/example/paycheck/api/user/UserController.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.MediaType;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "사용자", description = "사용자 정보 조회 및 관리 API")
@@ -48,6 +50,14 @@ public class UserController {
             @AuthenticationPrincipal User user,
             @Valid @RequestBody UserDto.UpdateRequest request) {
         return ApiResponse.success(userService.updateUser(user.getId(), request));
+    }
+
+    @Operation(summary = "내 프로필 이미지 업로드", description = "로그인한 사용자의 프로필 이미지를 S3에 업로드하고 URL을 반환합니다.")
+    @PostMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<UserDto.ProfileImageUploadResponse> uploadMyProfileImage(
+            @AuthenticationPrincipal User user,
+            @Parameter(description = "프로필 이미지 파일", required = true) @RequestPart("file") MultipartFile file) {
+        return ApiResponse.success(userService.uploadProfileImage(user.getId(), file));
     }
 
     @Operation(summary = "계좌 정보 수정 (근로자 전용)", description = "로그인한 근로자의 계좌 정보를 수정합니다.")

--- a/src/main/java/com/example/paycheck/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/paycheck/common/exception/ErrorCode.java
@@ -85,6 +85,9 @@ public class ErrorCode {
     public static final String DUPLICATE_BUSINESS_NUMBER = "DUPLICATE_BUSINESS_NUMBER";
     public static final String INVALID_BUSINESS_NUMBER = "INVALID_BUSINESS_NUMBER";
     public static final String BUSINESS_NUMBER_VERIFICATION_FAILED = "BUSINESS_NUMBER_VERIFICATION_FAILED";
+    public static final String INVALID_PROFILE_IMAGE_FILE = "INVALID_PROFILE_IMAGE_FILE";
+    public static final String PROFILE_IMAGE_UPLOAD_FAILED = "PROFILE_IMAGE_UPLOAD_FAILED";
+    public static final String PROFILE_IMAGE_UPLOAD_NOT_CONFIGURED = "PROFILE_IMAGE_UPLOAD_NOT_CONFIGURED";
 
     // Concurrency
     public static final String SALARY_LOCK_TIMEOUT = "SALARY_LOCK_TIMEOUT";

--- a/src/main/java/com/example/paycheck/common/exception/FileUploadException.java
+++ b/src/main/java/com/example/paycheck/common/exception/FileUploadException.java
@@ -1,0 +1,21 @@
+package com.example.paycheck.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class FileUploadException extends RuntimeException {
+    private final String errorCode;
+    private final String errorMessage;
+
+    public FileUploadException(String errorCode, String errorMessage) {
+        super(errorMessage);
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public FileUploadException(String errorCode, String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/example/paycheck/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/paycheck/common/exception/GlobalExceptionHandler.java
@@ -44,6 +44,13 @@ public class GlobalExceptionHandler {
         return ApiResponse.error(e.getErrorCode(), e.getErrorMessage());
     }
 
+    @ExceptionHandler(FileUploadException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiResponse<Void> handleFileUploadException(FileUploadException e) {
+        log.error("FileUploadException: {}", e.getErrorMessage(), e);
+        return ApiResponse.error(e.getErrorCode(), e.getErrorMessage());
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<Void> handleIllegalArgumentException(IllegalArgumentException e) {

--- a/src/main/java/com/example/paycheck/domain/user/dto/UserDto.java
+++ b/src/main/java/com/example/paycheck/domain/user/dto/UserDto.java
@@ -73,6 +73,21 @@ public class UserDto {
         private String profileImageUrl;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "ProfileImageUploadResponse")
+    public static class ProfileImageUploadResponse {
+        private String profileImageUrl;
+
+        public static ProfileImageUploadResponse from(String profileImageUrl) {
+            return ProfileImageUploadResponse.builder()
+                    .profileImageUrl(profileImageUrl)
+                    .build();
+        }
+    }
+
     /**
      * 내부 전용 DTO - 서비스 레이어에서만 사용
      * AuthService에서 OAuth 정보와 클라이언트 입력을 조합하여 생성

--- a/src/main/java/com/example/paycheck/domain/user/entity/User.java
+++ b/src/main/java/com/example/paycheck/domain/user/entity/User.java
@@ -47,6 +47,10 @@ public class User extends BaseEntity {
         if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
     }
 
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
     public void withdraw() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/example/paycheck/domain/user/service/ProfileImageStorageService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/ProfileImageStorageService.java
@@ -1,0 +1,138 @@
+package com.example.paycheck.domain.user.service;
+
+import com.example.paycheck.common.exception.BadRequestException;
+import com.example.paycheck.common.exception.ErrorCode;
+import com.example.paycheck.common.exception.FileUploadException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class ProfileImageStorageService {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/gif",
+            "image/webp",
+            "image/heic",
+            "image/heif"
+    );
+    private static final String DEFAULT_PROFILE_IMAGE_DIR = "profiles";
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String profileImageDir;
+
+    public ProfileImageStorageService(
+            S3Client s3Client,
+            @Value("${aws.s3.bucket:}") String bucket,
+            @Value("${aws.s3.profile-image-dir:profiles}") String profileImageDir) {
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.profileImageDir = normalizeProfileImageDir(profileImageDir);
+    }
+
+    public String uploadProfileImage(Long userId, MultipartFile file) {
+        validateFile(file);
+        validateBucketConfiguration();
+
+        String contentType = file.getContentType();
+        String objectKey = buildObjectKey(userId, file);
+
+        try (InputStream inputStream = file.getInputStream()) {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, file.getSize()));
+
+            URL uploadedFileUrl = s3Client.utilities()
+                    .getUrl(GetUrlRequest.builder().bucket(bucket).key(objectKey).build());
+
+            return uploadedFileUrl.toExternalForm();
+        } catch (IOException | SdkException e) {
+            throw new FileUploadException(
+                    ErrorCode.PROFILE_IMAGE_UPLOAD_FAILED,
+                    "프로필 이미지 업로드에 실패했습니다.",
+                    e
+            );
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BadRequestException(ErrorCode.INVALID_PROFILE_IMAGE_FILE, "업로드할 이미지 파일이 비어 있습니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (!StringUtils.hasText(contentType) || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase(Locale.ROOT))) {
+            throw new BadRequestException(
+                    ErrorCode.INVALID_PROFILE_IMAGE_FILE,
+                    "프로필 이미지는 JPG, PNG, GIF, WEBP, HEIC 형식만 업로드할 수 있습니다."
+            );
+        }
+    }
+
+    private void validateBucketConfiguration() {
+        if (!StringUtils.hasText(bucket)) {
+            throw new FileUploadException(
+                    ErrorCode.PROFILE_IMAGE_UPLOAD_NOT_CONFIGURED,
+                    "프로필 이미지 업로드를 위한 S3 버킷 설정이 필요합니다."
+            );
+        }
+    }
+
+    private String buildObjectKey(Long userId, MultipartFile file) {
+        String extension = resolveExtension(file);
+        String fileName = UUID.randomUUID() + (StringUtils.hasText(extension) ? "." + extension : "");
+        return profileImageDir + "/" + userId + "/" + fileName;
+    }
+
+    private String resolveExtension(MultipartFile file) {
+        String originalExtension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        if (StringUtils.hasText(originalExtension)) {
+            return sanitizeExtension(originalExtension);
+        }
+
+        return switch (file.getContentType().toLowerCase(Locale.ROOT)) {
+            case "image/jpeg", "image/jpg" -> "jpg";
+            case "image/png" -> "png";
+            case "image/gif" -> "gif";
+            case "image/webp" -> "webp";
+            case "image/heic" -> "heic";
+            case "image/heif" -> "heif";
+            default -> "";
+        };
+    }
+
+    private String sanitizeExtension(String extension) {
+        String normalizedExtension = extension.toLowerCase(Locale.ROOT);
+        return normalizedExtension.matches("[a-z0-9]+") ? normalizedExtension : "";
+    }
+
+    private String normalizeProfileImageDir(String profileImageDir) {
+        if (!StringUtils.hasText(profileImageDir)) {
+            return DEFAULT_PROFILE_IMAGE_DIR;
+        }
+
+        String normalizedProfileImageDir = profileImageDir.replaceAll("^/+", "").replaceAll("/+$", "");
+        return StringUtils.hasText(normalizedProfileImageDir) ? normalizedProfileImageDir : DEFAULT_PROFILE_IMAGE_DIR;
+    }
+}

--- a/src/main/java/com/example/paycheck/domain/user/service/UserService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import com.example.paycheck.domain.worker.service.WorkerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +26,7 @@ public class UserService {
     private final WorkerService workerService;
     private final EmployerService employerService;
     private final UserSettingsService userSettingsService;
+    private final ProfileImageStorageService profileImageStorageService;
 
     public UserDto.Response getUserById(Long userId) {
         User user = userRepository.findById(userId)
@@ -46,6 +48,14 @@ public class UserService {
         user.updateProfile(request.getName(), request.getPhone(), request.getProfileImageUrl());
 
         return UserDto.Response.from(user);
+    }
+
+    public UserDto.ProfileImageUploadResponse uploadProfileImage(Long userId, MultipartFile file) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        String profileImageUrl = profileImageStorageService.uploadProfileImage(userId, file);
+        return UserDto.ProfileImageUploadResponse.from(profileImageUrl);
     }
 
     @Transactional

--- a/src/main/java/com/example/paycheck/domain/user/service/UserService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserService.java
@@ -50,11 +50,13 @@ public class UserService {
         return UserDto.Response.from(user);
     }
 
+    @Transactional
     public UserDto.ProfileImageUploadResponse uploadProfileImage(Long userId, MultipartFile file) {
-        userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         String profileImageUrl = profileImageStorageService.uploadProfileImage(userId, file);
+        user.updateProfileImage(profileImageUrl);
         return UserDto.ProfileImageUploadResponse.from(profileImageUrl);
     }
 

--- a/src/main/java/com/example/paycheck/global/config/S3Config.java
+++ b/src/main/java/com/example/paycheck/global/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.example.paycheck.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+    @Bean(destroyMethod = "close")
+    public S3Client s3Client(
+            @Value("${aws.s3.region:ap-northeast-2}") String region,
+            @Value("${aws.s3.access-key:}") String accessKey,
+            @Value("${aws.s3.secret-key:}") String secretKey) {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(region));
+
+        if (StringUtils.hasText(accessKey) && StringUtils.hasText(secretKey)) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+            ));
+        } else {
+            builder.credentialsProvider(DefaultCredentialsProvider.create());
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -15,6 +15,13 @@ cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
 # Encryption Configuration - 반드시 환경변수로 주입
 encryption.aes-key=${ENCRYPTION_AES_KEY}
 
+# AWS S3 Configuration - 반드시 환경변수 또는 IAM Role로 설정
+aws.s3.bucket=${AWS_S3_BUCKET}
+aws.s3.region=${AWS_S3_REGION:ap-northeast-2}
+aws.s3.profile-image-dir=${AWS_S3_PROFILE_IMAGE_DIR:profiles}
+aws.s3.access-key=${AWS_S3_ACCESS_KEY:}
+aws.s3.secret-key=${AWS_S3_SECRET_KEY:}
+
 # JPA Configuration - prod 환경 최적화
 spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,3 +67,10 @@ encryption.aes-key=IuQq5A+rPiWgKR/qdPd3TOugPl1oVW67AUMxctc81hg=
 
 # Firebase Configuration
 firebase.service-account-file=firebase-service-account.json
+
+# AWS S3 Configuration
+aws.s3.bucket=${AWS_S3_BUCKET:}
+aws.s3.region=${AWS_S3_REGION:ap-northeast-2}
+aws.s3.profile-image-dir=${AWS_S3_PROFILE_IMAGE_DIR:profiles}
+aws.s3.access-key=${AWS_S3_ACCESS_KEY:}
+aws.s3.secret-key=${AWS_S3_SECRET_KEY:}

--- a/src/test/java/com/example/paycheck/api/user/UserControllerTest.java
+++ b/src/test/java/com/example/paycheck/api/user/UserControllerTest.java
@@ -1,0 +1,93 @@
+package com.example.paycheck.api.user;
+
+import com.example.paycheck.domain.user.dto.UserDto;
+import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.user.enums.UserType;
+import com.example.paycheck.domain.user.service.UserService;
+import com.example.paycheck.domain.worker.service.WorkerService;
+import com.example.paycheck.global.security.JwtAuthenticationFilter;
+import com.example.paycheck.global.security.JwtTokenProvider;
+import com.example.paycheck.global.security.permission.CustomPermissionEvaluator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("UserController 테스트")
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private WorkerService workerService;
+
+    @MockitoBean
+    private CustomPermissionEvaluator permissionEvaluator;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .kakaoId("12345")
+                .name("테스트")
+                .userType(UserType.WORKER)
+                .build();
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(testUser, null, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        given(permissionEvaluator.canAccessUser(anyLong())).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 - 성공")
+    void uploadMyProfileImage_success() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "image-content".getBytes()
+        );
+
+        given(userService.uploadProfileImage(eq(1L), any()))
+                .willReturn(UserDto.ProfileImageUploadResponse.from(
+                        "https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png"
+                ));
+
+        mockMvc.perform(multipart("/api/users/me/profile-image").file(file))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.profileImageUrl").value(
+                        "https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png"
+                ));
+    }
+}

--- a/src/test/java/com/example/paycheck/domain/user/service/ProfileImageStorageServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/ProfileImageStorageServiceTest.java
@@ -1,0 +1,90 @@
+package com.example.paycheck.domain.user.service;
+
+import com.example.paycheck.common.exception.BadRequestException;
+import com.example.paycheck.common.exception.FileUploadException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ProfileImageStorageService 테스트")
+class ProfileImageStorageServiceTest {
+
+    @Test
+    @DisplayName("프로필 이미지를 S3에 업로드하고 URL을 반환한다")
+    void uploadProfileImage_Success() throws Exception {
+        S3Client s3Client = mock(S3Client.class);
+        S3Utilities s3Utilities = mock(S3Utilities.class);
+        ProfileImageStorageService service = new ProfileImageStorageService(s3Client, "test-bucket", "profiles");
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "image-content".getBytes()
+        );
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().eTag("etag").build());
+        when(s3Client.utilities()).thenReturn(s3Utilities);
+        when(s3Utilities.getUrl(any(GetUrlRequest.class)))
+                .thenReturn(new URL("https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png"));
+
+        String result = service.uploadProfileImage(1L, file);
+
+        assertThat(result).isEqualTo("https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png");
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 파일은 업로드할 수 없다")
+    void uploadProfileImage_Fail_InvalidContentType() {
+        S3Client s3Client = mock(S3Client.class);
+        ProfileImageStorageService service = new ProfileImageStorageService(s3Client, "test-bucket", "profiles");
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.txt",
+                "text/plain",
+                "not-image".getBytes()
+        );
+
+        assertThatThrownBy(() -> service.uploadProfileImage(1L, file))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("프로필 이미지는");
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    @DisplayName("S3 버킷이 설정되지 않으면 업로드할 수 없다")
+    void uploadProfileImage_Fail_MissingBucket() {
+        S3Client s3Client = mock(S3Client.class);
+        ProfileImageStorageService service = new ProfileImageStorageService(s3Client, "", "profiles");
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "image-content".getBytes()
+        );
+
+        assertThatThrownBy(() -> service.uploadProfileImage(1L, file))
+                .isInstanceOf(FileUploadException.class)
+                .hasMessageContaining("S3 버킷 설정");
+        verifyNoInteractions(s3Client);
+    }
+}

--- a/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
@@ -18,12 +18,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +44,9 @@ class UserServiceTest {
 
     @Mock
     private UserSettingsService userSettingsService;
+
+    @Mock
+    private ProfileImageStorageService profileImageStorageService;
 
     @InjectMocks
     private UserService userService;
@@ -90,6 +93,31 @@ class UserServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("사용자를 찾을 수 없습니다");
         verify(userRepository).findById(999L);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 성공")
+    void uploadProfileImage_Success() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "image-content".getBytes()
+        );
+        String uploadedUrl = "https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png";
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(profileImageStorageService.uploadProfileImage(1L, file)).thenReturn(uploadedUrl);
+
+        // when
+        UserDto.ProfileImageUploadResponse result = userService.uploadProfileImage(1L, file);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getProfileImageUrl()).isEqualTo(uploadedUrl);
+        verify(userRepository).findById(1L);
+        verify(profileImageStorageService).uploadProfileImage(1L, file);
     }
 
     @Test

--- a/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
@@ -116,6 +116,7 @@ class UserServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getProfileImageUrl()).isEqualTo(uploadedUrl);
+        assertThat(testUser.getProfileImageUrl()).isEqualTo(uploadedUrl);
         verify(userRepository).findById(1L);
         verify(profileImageStorageService).uploadProfileImage(1L, file);
     }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -38,3 +38,10 @@ spring.cache.type=none
 
 # Firebase Configuration (테스트 환경에서는 비활성화)
 firebase.service-account-file=
+
+# AWS S3 Configuration (테스트 기본값)
+aws.s3.bucket=test-bucket
+aws.s3.region=ap-northeast-2
+aws.s3.profile-image-dir=profiles
+aws.s3.access-key=
+aws.s3.secret-key=


### PR DESCRIPTION
## Summary
- add profile image upload API for users
- add S3 storage configuration and upload error handling
- add controller and service tests for profile image upload

## Test
- ./gradlew test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 프로필 이미지 업로드 기능 추가
  * JPEG, PNG, GIF, WEBP, HEIC, HEIF 형식의 이미지 지원
  * AWS S3를 통한 안전한 이미지 저장소 통합
  * 파일 형식 검증 및 업로드 오류 처리 개선

* **Documentation**
  * API 명세서에 프로필 이미지 업로드 엔드포인트 추가 및 사용 예시 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->