### PR TITLE
[bug] 정정요청 승인 시 근무일 및 휴게시간 반영 오류 수정

### DIFF
--- a/src/main/java/com/example/paycheck/domain/correction/service/CorrectionRequestService.java
+++ b/src/main/java/com/example/paycheck/domain/correction/service/CorrectionRequestService.java
@@ -20,6 +20,7 @@ import com.example.paycheck.domain.workrecord.dto.WorkRecordDto;
 import com.example.paycheck.domain.workrecord.entity.WorkRecord;
 import com.example.paycheck.domain.workrecord.repository.WorkRecordRepository;
 import com.example.paycheck.domain.workrecord.service.WorkRecordCommandService;
+import com.example.paycheck.domain.workrecord.service.WorkRecordCalculationService;
 import com.example.paycheck.domain.workrecord.service.WorkRecordCoordinatorService;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,7 +33,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +51,7 @@ public class CorrectionRequestService {
     private final WorkRecordRepository workRecordRepository;
     private final WorkerContractRepository workerContractRepository;
     private final WorkRecordCommandService workRecordCommandService;
+    private final WorkRecordCalculationService calculationService;
     private final WorkRecordCoordinatorService coordinatorService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -342,15 +346,57 @@ public class CorrectionRequestService {
 
         // 기존 WeeklyAllowance 저장 (재계산용)
         WeeklyAllowance oldWeeklyAllowance = workRecord.getWeeklyAllowance();
+        LocalDate originalWorkDate = workRecord.getWorkDate();
+        LocalDate requestedWorkDate = correctionRequest.getRequestedWorkDate() != null
+                ? correctionRequest.getRequestedWorkDate()
+                : originalWorkDate;
+        java.time.LocalTime requestedStartTime = correctionRequest.getRequestedStartTime() != null
+                ? correctionRequest.getRequestedStartTime()
+                : workRecord.getStartTime();
+        java.time.LocalTime requestedEndTime = correctionRequest.getRequestedEndTime() != null
+                ? correctionRequest.getRequestedEndTime()
+                : workRecord.getEndTime();
+
+        Integer requestedBreakMinutes = correctionRequest.getRequestedBreakMinutes() != null
+                ? correctionRequest.getRequestedBreakMinutes()
+                : workRecord.getBreakMinutes();
+        int totalWorkMinutes = calculateWorkMinutes(
+                requestedWorkDate,
+                requestedStartTime,
+                requestedEndTime,
+                requestedBreakMinutes
+        );
+
+        if (oldWeeklyAllowance != null) {
+            workRecord.removeFromWeeklyAllowance();
+        }
+
+        WeeklyAllowance newWeeklyAllowance = coordinatorService.getOrCreateWeeklyAllowance(
+                workRecord.getContract().getId(),
+                requestedWorkDate);
+
+        workRecord.assignToWeeklyAllowance(newWeeklyAllowance);
+        workRecord.addToWeeklyAllowance();
 
         // WorkRecord 업데이트
-        workRecord.updateWorkTime(
-                correctionRequest.getRequestedStartTime(),
-                correctionRequest.getRequestedEndTime(),
+        workRecord.updateWorkRecord(
+                requestedWorkDate,
+                requestedStartTime,
+                requestedEndTime,
+                requestedBreakMinutes,
+                totalWorkMinutes,
                 correctionRequest.getRequestedMemo());
 
+        workRecordRepository.save(workRecord);
+
+        if (workRecord.getStatus() == WorkRecordStatus.COMPLETED) {
+            calculationService.calculateWorkRecordDetails(workRecord);
+            calculationService.validateWorkRecordConsistency(workRecord);
+            workRecordRepository.save(workRecord);
+        }
+
         // WeeklyAllowance 및 Salary 재계산
-        coordinatorService.handleWorkRecordUpdate(workRecord, oldWeeklyAllowance, workRecord.getWeeklyAllowance());
+        coordinatorService.handleWorkRecordUpdate(workRecord, oldWeeklyAllowance, newWeeklyAllowance, originalWorkDate);
     }
 
     private void approveDeleteRequest(CorrectionRequest correctionRequest) {
@@ -443,5 +489,17 @@ public class CorrectionRequestService {
             log.error("알림 액션 데이터 생성 실패: correctionRequestId={}", correctionRequestId, e);
             return null;
         }
+    }
+
+    private int calculateWorkMinutes(LocalDate workDate, java.time.LocalTime startTime, java.time.LocalTime endTime, int breakMinutes) {
+        LocalDateTime startDateTime = LocalDateTime.of(workDate, startTime);
+        LocalDateTime endDateTime = LocalDateTime.of(workDate, endTime);
+
+        if (!endTime.isAfter(startTime)) {
+            endDateTime = endDateTime.plusDays(1);
+        }
+
+        long totalMinutes = Duration.between(startDateTime, endDateTime).toMinutes();
+        return (int) (totalMinutes - breakMinutes);
     }
 }

--- a/src/main/java/com/example/paycheck/domain/workrecord/entity/WorkRecord.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/entity/WorkRecord.java
@@ -135,6 +135,11 @@ public class WorkRecord extends BaseEntity {
     // 근무 기록 수정
     // 계산은 WorkRecordCalculationService에서 수행
     public void updateWorkRecord(LocalTime startTime, LocalTime endTime, Integer breakMinutes, Integer totalWorkMinutes, String memo) {
+        updateWorkRecord(null, startTime, endTime, breakMinutes, totalWorkMinutes, memo);
+    }
+
+    public void updateWorkRecord(LocalDate workDate, LocalTime startTime, LocalTime endTime, Integer breakMinutes, Integer totalWorkMinutes, String memo) {
+        if (workDate != null) this.workDate = workDate;
         if (startTime != null) this.startTime = startTime;
         if (endTime != null) this.endTime = endTime;
         if (breakMinutes != null) this.breakMinutes = breakMinutes;

--- a/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordCoordinatorService.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordCoordinatorService.java
@@ -17,6 +17,7 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 /**
@@ -70,6 +71,17 @@ public class WorkRecordCoordinatorService {
      * COMPLETED 상태일 때만 급여 재계산
      */
     public void handleWorkRecordUpdate(WorkRecord workRecord, WeeklyAllowance oldWeeklyAllowance, WeeklyAllowance newWeeklyAllowance) {
+        handleWorkRecordUpdate(workRecord, oldWeeklyAllowance, newWeeklyAllowance, workRecord.getWorkDate());
+    }
+
+    /**
+     * 근무 기록 수정 시 원래 근무일을 기준으로 WeeklyAllowance/급여 재계산 처리
+     */
+    public void handleWorkRecordUpdate(
+            WorkRecord workRecord,
+            WeeklyAllowance oldWeeklyAllowance,
+            WeeklyAllowance newWeeklyAllowance,
+            LocalDate originalWorkDate) {
         // 기존 WeeklyAllowance 수당 재계산 (다른 WeeklyAllowance였다면)
         if (oldWeeklyAllowance != null && newWeeklyAllowance != null && !oldWeeklyAllowance.getId().equals(newWeeklyAllowance.getId())) {
             weeklyAllowanceService.recalculateAllowances(oldWeeklyAllowance.getId());
@@ -80,9 +92,13 @@ public class WorkRecordCoordinatorService {
             weeklyAllowanceService.recalculateAllowances(newWeeklyAllowance.getId());
         }
 
+        if (!originalWorkDate.equals(workRecord.getWorkDate())) {
+            recalculatePreviousWeekAllowances(workRecord.getContract().getId(), originalWorkDate, workRecord.getWorkDate());
+        }
+
         // COMPLETED 상태일 때만 급여 재계산
         if (workRecord.getStatus() == WorkRecordStatus.COMPLETED) {
-            recalculateSalaryForWorkRecord(workRecord);
+            recalculateSalaryForWorkRecordUpdate(workRecord, originalWorkDate);
         }
     }
 
@@ -132,6 +148,18 @@ public class WorkRecordCoordinatorService {
                 workRecord.getWorkDate());
     }
 
+    private void recalculateSalaryForWorkRecordUpdate(WorkRecord workRecord, LocalDate originalWorkDate) {
+        Long contractId = workRecord.getContract().getId();
+        Integer paymentDay = workRecord.getContract().getPaymentDay();
+        LocalDate updatedWorkDate = workRecord.getWorkDate();
+
+        if (!getSalaryPeriodKey(paymentDay, originalWorkDate).equals(getSalaryPeriodKey(paymentDay, updatedWorkDate))) {
+            recalculateSalaryForDate(contractId, paymentDay, originalWorkDate);
+        }
+
+        recalculateSalaryForDate(contractId, paymentDay, updatedWorkDate);
+    }
+
     /**
      * 특정 날짜 기준으로 해당 월의 급여 재계산
      * 계약 종료 등 WorkRecord 없이 날짜 기준으로 재계산이 필요한 경우 사용
@@ -165,6 +193,33 @@ public class WorkRecordCoordinatorService {
                 workRecord.getContract().getId(), previousWeekStart)
             .ifPresent(prevAllowance ->
                 weeklyAllowanceService.recalculateAllowances(prevAllowance.getId()));
+    }
+
+    private void recalculatePreviousWeekAllowances(Long contractId, LocalDate... workDates) {
+        Stream.of(workDates)
+                .map(this::getPreviousWeekStart)
+                .distinct()
+                .forEach(previousWeekStart ->
+                        weeklyAllowanceRepository.findByContractAndWeek(contractId, previousWeekStart)
+                                .ifPresent(previousAllowance ->
+                                        weeklyAllowanceService.recalculateAllowances(previousAllowance.getId())));
+    }
+
+    private LocalDate getPreviousWeekStart(LocalDate workDate) {
+        return workDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).minusWeeks(1);
+    }
+
+    private String getSalaryPeriodKey(Integer paymentDay, LocalDate date) {
+        int year = date.getYear();
+        int month = date.getMonthValue();
+
+        if (date.getDayOfMonth() >= paymentDay) {
+            LocalDate nextMonth = date.plusMonths(1);
+            year = nextMonth.getYear();
+            month = nextMonth.getMonthValue();
+        }
+
+        return year + "_" + month;
     }
 
     /**

--- a/src/test/java/com/example/paycheck/domain/correction/service/CorrectionRequestServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/correction/service/CorrectionRequestServiceTest.java
@@ -2,20 +2,30 @@ package com.example.paycheck.domain.correction.service;
 
 import com.example.paycheck.common.exception.BadRequestException;
 import com.example.paycheck.common.exception.NotFoundException;
+import com.example.paycheck.domain.allowance.entity.WeeklyAllowance;
+import com.example.paycheck.domain.contract.entity.WorkerContract;
+import com.example.paycheck.domain.contract.repository.WorkerContractRepository;
 import com.example.paycheck.domain.correction.dto.CorrectionRequestDto;
+import com.example.paycheck.domain.correction.entity.CorrectionRequest;
 import com.example.paycheck.domain.correction.enums.CorrectionStatus;
 import com.example.paycheck.domain.correction.repository.CorrectionRequestRepository;
+import com.example.paycheck.domain.correction.service.CorrectionRequestService;
+import com.example.paycheck.domain.notification.event.NotificationEvent;
 import com.example.paycheck.domain.user.entity.User;
 import com.example.paycheck.domain.workrecord.entity.WorkRecord;
 import com.example.paycheck.domain.workrecord.repository.WorkRecordRepository;
 import com.example.paycheck.domain.correction.enums.RequestType;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
+import com.example.paycheck.domain.workrecord.service.WorkRecordCalculationService;
+import com.example.paycheck.domain.workrecord.service.WorkRecordCommandService;
+import com.example.paycheck.domain.workrecord.service.WorkRecordCoordinatorService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -36,6 +46,21 @@ class CorrectionRequestServiceTest {
 
     @Mock
     private WorkRecordRepository workRecordRepository;
+
+    @Mock
+    private WorkerContractRepository workerContractRepository;
+
+    @Mock
+    private WorkRecordCommandService workRecordCommandService;
+
+    @Mock
+    private WorkRecordCalculationService calculationService;
+
+    @Mock
+    private WorkRecordCoordinatorService coordinatorService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private CorrectionRequestService correctionRequestService;
@@ -131,5 +156,91 @@ class CorrectionRequestServiceTest {
         // when & then
         assertThatThrownBy(() -> correctionRequestService.getMyCorrectionRequest(requester, 1L))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("정정요청 승인 시 근무일과 휴게시간이 수정되고 주차 재할당 및 재계산이 수행된다")
+    void approveCorrectionRequest_UpdateWorkDateAndBreakMinutes() {
+        // given
+        User requester = mock(User.class);
+        when(requester.getId()).thenReturn(10L);
+        when(requester.getName()).thenReturn("근로자");
+
+        WorkerContract contract = mock(WorkerContract.class);
+        when(contract.getId()).thenReturn(100L);
+
+        WeeklyAllowance oldWeeklyAllowance = WeeklyAllowance.builder()
+                .contract(contract)
+                .weekStartDate(LocalDate.of(2026, 2, 16))
+                .weekEndDate(LocalDate.of(2026, 2, 22))
+                .build();
+
+        WeeklyAllowance newWeeklyAllowance = WeeklyAllowance.builder()
+                .contract(contract)
+                .weekStartDate(LocalDate.of(2026, 2, 23))
+                .weekEndDate(LocalDate.of(2026, 3, 1))
+                .build();
+
+        WorkRecord workRecord = WorkRecord.builder()
+                .id(1L)
+                .contract(contract)
+                .weeklyAllowance(oldWeeklyAllowance)
+                .workDate(LocalDate.of(2026, 2, 21))
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(18, 0))
+                .breakMinutes(60)
+                .totalWorkMinutes(480)
+                .status(WorkRecordStatus.COMPLETED)
+                .memo("기존 메모")
+                .build();
+        oldWeeklyAllowance.getWorkRecords().add(workRecord);
+
+        CorrectionRequest correctionRequest = CorrectionRequest.builder()
+                .id(1L)
+                .type(RequestType.UPDATE)
+                .workRecord(workRecord)
+                .requester(requester)
+                .originalWorkDate(workRecord.getWorkDate())
+                .originalStartTime(workRecord.getStartTime())
+                .originalEndTime(workRecord.getEndTime())
+                .requestedWorkDate(LocalDate.of(2026, 2, 24))
+                .requestedStartTime(LocalTime.of(10, 0))
+                .requestedEndTime(LocalTime.of(19, 0))
+                .requestedBreakMinutes(30)
+                .requestedMemo("휴게시간 수정")
+                .status(CorrectionStatus.PENDING)
+                .build();
+
+        when(correctionRequestRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(correctionRequest));
+        when(coordinatorService.getOrCreateWeeklyAllowance(100L, LocalDate.of(2026, 2, 24)))
+                .thenReturn(newWeeklyAllowance);
+
+        // when
+        CorrectionRequestDto.Response result = correctionRequestService.approveCorrectionRequest(1L);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(CorrectionStatus.APPROVED);
+        assertThat(result.getRequestedWorkDate()).isEqualTo(LocalDate.of(2026, 2, 24));
+        assertThat(result.getRequestedBreakMinutes()).isEqualTo(30);
+        assertThat(workRecord.getWorkDate()).isEqualTo(LocalDate.of(2026, 2, 24));
+        assertThat(workRecord.getBreakMinutes()).isEqualTo(30);
+        assertThat(workRecord.getTotalWorkMinutes()).isEqualTo(510);
+        assertThat(workRecord.getStartTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(workRecord.getEndTime()).isEqualTo(LocalTime.of(19, 0));
+        assertThat(workRecord.getMemo()).isEqualTo("휴게시간 수정");
+        assertThat(workRecord.getWeeklyAllowance()).isEqualTo(newWeeklyAllowance);
+        assertThat(oldWeeklyAllowance.getWorkRecords()).doesNotContain(workRecord);
+        assertThat(newWeeklyAllowance.getWorkRecords()).contains(workRecord);
+
+        verify(workRecordRepository, times(2)).save(workRecord);
+        verify(calculationService).calculateWorkRecordDetails(workRecord);
+        verify(calculationService).validateWorkRecordConsistency(workRecord);
+        verify(coordinatorService).getOrCreateWeeklyAllowance(100L, LocalDate.of(2026, 2, 24));
+        verify(coordinatorService).handleWorkRecordUpdate(
+                workRecord,
+                oldWeeklyAllowance,
+                newWeeklyAllowance,
+                LocalDate.of(2026, 2, 21));
+        verify(eventPublisher).publishEvent(any(NotificationEvent.class));
     }
 }

--- a/src/test/java/com/example/paycheck/domain/workrecord/entity/WorkRecordTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/entity/WorkRecordTest.java
@@ -114,6 +114,30 @@ class WorkRecordTest {
     }
 
     @Test
+    @DisplayName("근무 기록 수정 시 근무일도 함께 변경할 수 있다")
+    void updateWorkRecord_WithWorkDate() {
+        // given
+        LocalDate newWorkDate = LocalDate.of(2024, 1, 16);
+        LocalTime newStart = LocalTime.of(8, 0);
+        LocalTime newEnd = LocalTime.of(17, 0);
+        Integer newBreakMinutes = 30;
+        Integer newTotalWorkMinutes = 510;
+        String memo = "근무일 변경";
+
+        // when
+        workRecord.updateWorkRecord(newWorkDate, newStart, newEnd, newBreakMinutes, newTotalWorkMinutes, memo);
+
+        // then
+        assertThat(workRecord.getWorkDate()).isEqualTo(newWorkDate);
+        assertThat(workRecord.getStartTime()).isEqualTo(newStart);
+        assertThat(workRecord.getEndTime()).isEqualTo(newEnd);
+        assertThat(workRecord.getBreakMinutes()).isEqualTo(newBreakMinutes);
+        assertThat(workRecord.getTotalWorkMinutes()).isEqualTo(newTotalWorkMinutes);
+        assertThat(workRecord.getMemo()).isEqualTo(memo);
+        assertThat(workRecord.getIsModified()).isTrue();
+    }
+
+    @Test
     @DisplayName("근무 완료 처리")
     void complete() {
         // when

--- a/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordCoordinatorServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordCoordinatorServiceTest.java
@@ -153,6 +153,30 @@ class WorkRecordCoordinatorServiceTest {
             // then
             verify(salaryService).recalculateSalaryAfterWorkRecordUpdate(eq(1L), eq(2024), eq(1));
         }
+
+        @Test
+        @DisplayName("근무일이 바뀐 COMPLETED 수정 - 이전/신규 급여 귀속월과 이전 주차를 모두 재계산한다")
+        void changedWorkDate_Completed_RecalculatesOldAndNewSalaryPeriods() {
+            // given
+            WeeklyAllowance oldAllowance = createMockAllowance(10L);
+            WeeklyAllowance newAllowance = createMockAllowance(20L);
+            WorkRecord workRecord = createMockWorkRecord(WorkRecordStatus.COMPLETED, LocalDate.of(2024, 2, 26), newAllowance);
+
+            // when
+            coordinatorService.handleWorkRecordUpdate(
+                    workRecord,
+                    oldAllowance,
+                    newAllowance,
+                    LocalDate.of(2024, 1, 24));
+
+            // then
+            verify(weeklyAllowanceService).recalculateAllowances(10L);
+            verify(weeklyAllowanceService).recalculateAllowances(20L);
+            verify(weeklyAllowanceRepository).findByContractAndWeek(1L, LocalDate.of(2024, 1, 15));
+            verify(weeklyAllowanceRepository).findByContractAndWeek(1L, LocalDate.of(2024, 2, 19));
+            verify(salaryService).recalculateSalaryAfterWorkRecordUpdate(1L, 2024, 1);
+            verify(salaryService).recalculateSalaryAfterWorkRecordUpdate(1L, 2024, 3);
+        }
     }
 
     @Nested


### PR DESCRIPTION
완료
## 변경 사항
- 정정요청 승인 시 근무일, 시작/종료시간, 휴게시간이 함께 반영되도록 수정했습니다.
- 근무일이 바뀌는 경우 주차 재할당과 급여/주휴수당 재계산이 올바르게 수행되도록 보완했습니다.

## 테스트
- ./gradlew test --tests 'com.example.paycheck.domain.correction.service.CorrectionRequestServiceTest' --tests 'com.example.paycheck.domain.workrecord.service.WorkRecordCoordinatorServiceTest' --tests 'com.example.paycheck.domain.workrecord.entity.WorkRecordTest'