### PR TITLE
[bug] 근무지 표시명 반영 오류 수정

### DIFF
--- a/src/main/java/com/example/paycheck/domain/workplace/dto/WorkplaceDto.java
+++ b/src/main/java/com/example/paycheck/domain/workplace/dto/WorkplaceDto.java
@@ -25,6 +25,9 @@ public class WorkplaceDto {
         @Pattern(regexp = "\\d{3}-\\d{2}-\\d{5}", message = "사업자 등록번호 형식이 올바르지 않습니다. (예: 123-45-67890)")
         private String businessNumber;
 
+        @Size(max = 100, message = "실제 근무지명은 100자 이하로 입력해주세요.")
+        private String businessName;
+
         @NotBlank(message = "근무지명은 필수입니다.")
         @Size(max = 100, message = "근무지명은 100자 이하로 입력해주세요.")
         private String name;
@@ -45,6 +48,9 @@ public class WorkplaceDto {
     @AllArgsConstructor
     @Schema(name = "WorkplaceUpdateRequest")
     public static class UpdateRequest {
+        @Size(min = 1, max = 100, message = "실제 근무지명은 1자 이상 100자 이하로 입력해주세요.")
+        private String businessName;
+
         @Size(min = 1, max = 100, message = "근무지명은 1자 이상 100자 이하로 입력해주세요.")
         private String name;
 
@@ -65,6 +71,7 @@ public class WorkplaceDto {
     public static class Response {
         private Long id;
         private String businessNumber;
+        private String businessName;
         private String name;
         private String address;
         private String colorCode;
@@ -77,7 +84,8 @@ public class WorkplaceDto {
             return Response.builder()
                     .id(workplace.getId())
                     .businessNumber(workplace.getBusinessNumber())
-                    .name(workplace.getName())
+                    .businessName(workplace.getBusinessName())
+                    .name(workplace.getDisplayName())
                     .address(workplace.getAddress())
                     .colorCode(workplace.getColorCode())
                     .isActive(workplace.getIsActive())
@@ -95,6 +103,7 @@ public class WorkplaceDto {
     @Schema(name = "WorkplaceListResponse")
     public static class ListResponse {
         private Long id;
+        private String businessName;
         private String name;
         private String colorCode;
         private Integer workerCount;
@@ -103,7 +112,8 @@ public class WorkplaceDto {
         public static ListResponse from(Workplace workplace, Integer workerCount) {
             return ListResponse.builder()
                     .id(workplace.getId())
-                    .name(workplace.getName())
+                    .businessName(workplace.getBusinessName())
+                    .name(workplace.getDisplayName())
                     .colorCode(workplace.getColorCode())
                     .workerCount(workerCount)
                     .isActive(workplace.getIsActive())

--- a/src/main/java/com/example/paycheck/domain/workplace/entity/Workplace.java
+++ b/src/main/java/com/example/paycheck/domain/workplace/entity/Workplace.java
@@ -24,6 +24,9 @@ public class Workplace extends BaseEntity {
     @Column(name = "business_number", unique = true, nullable = false)
     private String businessNumber;
 
+    @Column(name = "business_name")
+    private String businessName;
+
     @Column(name = "name", nullable = false)
     private String name;
 
@@ -41,11 +44,20 @@ public class Workplace extends BaseEntity {
     @Builder.Default
     private Boolean isLessThanFiveEmployees = true; // 5인 미만 여부 (고용주 선택)
 
-    public void update(String name, String address, String colorCode, Boolean isLessThanFiveEmployees) {
+    public String getDisplayName() {
+        return businessName != null && !businessName.isBlank() ? businessName : name;
+    }
+
+    public void update(String businessName, String name, String address, String colorCode, Boolean isLessThanFiveEmployees) {
+        if (businessName != null) this.businessName = businessName;
         if (name != null) this.name = name;
         if (address != null) this.address = address;
         if (colorCode != null) this.colorCode = colorCode;
         if (isLessThanFiveEmployees != null) this.isLessThanFiveEmployees = isLessThanFiveEmployees;
+    }
+
+    public void update(String name, String address, String colorCode, Boolean isLessThanFiveEmployees) {
+        update(null, name, address, colorCode, isLessThanFiveEmployees);
     }
 
     public void deactivate() {

--- a/src/main/java/com/example/paycheck/domain/workplace/service/WorkplaceService.java
+++ b/src/main/java/com/example/paycheck/domain/workplace/service/WorkplaceService.java
@@ -11,6 +11,7 @@ import com.example.paycheck.domain.workplace.repository.WorkplaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,6 +35,7 @@ public class WorkplaceService {
         Workplace workplace = Workplace.builder()
                 .employer(employer)
                 .businessNumber(request.getBusinessNumber())
+                .businessName(resolveBusinessName(request.getBusinessName(), request.getName()))
                 .name(request.getName())
                 .address(request.getAddress())
                 .colorCode(request.getColorCode())
@@ -69,6 +71,7 @@ public class WorkplaceService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.WORKPLACE_NOT_FOUND, "사업장을 찾을 수 없습니다."));
 
         workplace.update(
+                resolveBusinessName(request.getBusinessName(), request.getName()),
                 request.getName(),
                 request.getAddress(),
                 request.getColorCode(),
@@ -84,5 +87,9 @@ public class WorkplaceService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.WORKPLACE_NOT_FOUND, "사업장을 찾을 수 없습니다."));
 
         workplace.deactivate();
+    }
+
+    private String resolveBusinessName(String businessName, String fallbackName) {
+        return StringUtils.hasText(businessName) ? businessName : fallbackName;
     }
 }

--- a/src/test/java/com/example/paycheck/domain/workplace/entity/WorkplaceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workplace/entity/WorkplaceTest.java
@@ -21,6 +21,7 @@ class WorkplaceTest {
                 .id(1L)
                 .employer(mockEmployer)
                 .businessNumber("123-45-67890")
+                .businessName("실제 근무지명")
                 .name("본점")
                 .address("서울시 강남구")
                 .colorCode("#FF5733")
@@ -34,6 +35,7 @@ class WorkplaceTest {
     void update_AllFields() {
         // when
         workplace.update(
+                "수정된 실제 근무지명",
                 "지점",
                 "서울시 서초구",
                 "#33FF57",
@@ -41,6 +43,7 @@ class WorkplaceTest {
         );
 
         // then
+        assertThat(workplace.getBusinessName()).isEqualTo("수정된 실제 근무지명");
         assertThat(workplace.getName()).isEqualTo("지점");
         assertThat(workplace.getAddress()).isEqualTo("서울시 서초구");
         assertThat(workplace.getColorCode()).isEqualTo("#33FF57");
@@ -74,6 +77,24 @@ class WorkplaceTest {
 
         // then
         assertThat(workplace.getName()).isEqualTo(originalName);
+    }
+
+    @Test
+    @DisplayName("표시용 근무지명은 실제 근무지명을 우선 사용")
+    void getDisplayName_UsesBusinessNameFirst() {
+        assertThat(workplace.getDisplayName()).isEqualTo("실제 근무지명");
+    }
+
+    @Test
+    @DisplayName("실제 근무지명이 없으면 기존 근무지명으로 표시")
+    void getDisplayName_FallbackToName() {
+        Workplace workplaceWithoutBusinessName = Workplace.builder()
+                .employer(mockEmployer)
+                .businessNumber("999-99-99999")
+                .name("기존 근무지명")
+                .build();
+
+        assertThat(workplaceWithoutBusinessName.getDisplayName()).isEqualTo("기존 근무지명");
     }
 
     @Test

--- a/src/test/java/com/example/paycheck/domain/workplace/service/WorkplaceServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workplace/service/WorkplaceServiceTest.java
@@ -58,7 +58,8 @@ class WorkplaceServiceTest {
                 .id(1L)
                 .employer(testEmployer)
                 .businessNumber("123-45-67890")
-                .name("테스트 사업장")
+                .businessName("실제 근무지명")
+                .name("앱 내부 별칭")
                 .address("서울시 강남구")
                 .isActive(true)
                 .build();
@@ -70,6 +71,7 @@ class WorkplaceServiceTest {
         // given
         WorkplaceDto.CreateRequest request = WorkplaceDto.CreateRequest.builder()
                 .businessNumber("123-45-67890")
+                .businessName("실제 근무지명")
                 .name("테스트 사업장")
                 .address("서울시 강남구")
                 .colorCode("#FF0000")
@@ -94,6 +96,7 @@ class WorkplaceServiceTest {
         // given
         WorkplaceDto.CreateRequest request = WorkplaceDto.CreateRequest.builder()
                 .businessNumber("123-45-67890")
+                .businessName("실제 근무지명")
                 .name("테스트 사업장")
                 .address("서울시 강남구")
                 .colorCode("#FF0000")
@@ -153,6 +156,8 @@ class WorkplaceServiceTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result.get(0).getBusinessName()).isEqualTo("실제 근무지명");
+        assertThat(result.get(0).getName()).isEqualTo("실제 근무지명");
         verify(employerService).getEmployerByUserId(1L);
         verify(workplaceRepository).findByEmployerIdAndIsActive(1L, true);
     }
@@ -162,6 +167,7 @@ class WorkplaceServiceTest {
     void updateWorkplace_Success() {
         // given
         WorkplaceDto.UpdateRequest request = WorkplaceDto.UpdateRequest.builder()
+                .businessName("수정된 실제 근무지명")
                 .name("수정된 사업장")
                 .address("서울시 서초구")
                 .colorCode("#00FF00")
@@ -176,5 +182,32 @@ class WorkplaceServiceTest {
         // then
         assertThat(result).isNotNull();
         verify(workplaceRepository).findById(1L);
+    }
+
+    @Test
+    @DisplayName("사업장 목록 조회 시 실제 근무지명이 없으면 기존 근무지명으로 표시")
+    void getWorkplacesByUserId_FallbackToNameWhenBusinessNameMissing() {
+        // given
+        Workplace workplaceWithoutBusinessName = Workplace.builder()
+                .id(2L)
+                .employer(testEmployer)
+                .businessNumber("234-56-78901")
+                .name("기존 근무지명")
+                .address("서울시 마포구")
+                .isActive(true)
+                .build();
+
+        when(employerService.getEmployerByUserId(1L)).thenReturn(testEmployer);
+        when(workplaceRepository.findByEmployerIdAndIsActive(1L, true))
+                .thenReturn(Collections.singletonList(workplaceWithoutBusinessName));
+        when(workerContractRepository.countByWorkplaceIdAndIsActive(2L, true)).thenReturn(2);
+
+        // when
+        List<WorkplaceDto.ListResponse> result = workplaceService.getWorkplacesByUserId(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getBusinessName()).isNull();
+        assertThat(result.get(0).getName()).isEqualTo("기존 근무지명");
     }
 }


### PR DESCRIPTION
완료
## 변경 사항
- 사업장에 실제 표시명(businessName)을 저장하고, 없으면 기존 name으로 fallback 하도록 수정했습니다.
- 사업장 조회 응답이 표시용 이름을 일관되게 사용하도록 정리했습니다.

## 테스트
- ./gradlew test --tests 'com.example.paycheck.domain.workplace.entity.WorkplaceTest' --tests 'com.example.paycheck.domain.workplace.service.WorkplaceServiceTest'