### PR TITLE
[bug] 근무 목록 current status 정렬 오류 수정

### DIFF
--- a/src/main/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDto.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDto.java
@@ -1,6 +1,7 @@
 package com.example.paycheck.domain.workrecord.dto;
 
 import com.example.paycheck.domain.workrecord.entity.WorkRecord;
+import com.example.paycheck.domain.workrecord.enums.WorkRecordCurrentStatus;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -78,6 +79,8 @@ public class WorkRecordDto {
         private Integer breakMinutes;
         private Integer totalWorkMinutes;
         private WorkRecordStatus status;
+        @Schema(description = "현재 시점 기준 근무 상태 (IN_PROGRESS/UPCOMING/COMPLETED)")
+        private WorkRecordCurrentStatus currentStatus;
         private Boolean isModified;
         private String memo;
         @Schema(description = "시급")
@@ -92,6 +95,13 @@ public class WorkRecordDto {
         private BigDecimal totalSalary;
 
         public static DetailedResponse from(WorkRecord workRecord) {
+            WorkRecordCurrentStatus currentStatus = workRecord.getStatus() == WorkRecordStatus.COMPLETED
+                    ? WorkRecordCurrentStatus.COMPLETED
+                    : WorkRecordCurrentStatus.UPCOMING;
+            return from(workRecord, currentStatus);
+        }
+
+        public static DetailedResponse from(WorkRecord workRecord, WorkRecordCurrentStatus currentStatus) {
             return DetailedResponse.builder()
                     .id(workRecord.getId())
                     .contractId(workRecord.getContract().getId())
@@ -104,6 +114,7 @@ public class WorkRecordDto {
                     .breakMinutes(workRecord.getBreakMinutes())
                     .totalWorkMinutes(workRecord.getTotalWorkMinutes())
                     .status(workRecord.getStatus())
+                    .currentStatus(currentStatus)
                     .isModified(workRecord.getIsModified())
                     .memo(workRecord.getMemo())
                     .hourlyWage(workRecord.getContract().getHourlyWage())

--- a/src/main/java/com/example/paycheck/domain/workrecord/enums/WorkRecordCurrentStatus.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/enums/WorkRecordCurrentStatus.java
@@ -1,0 +1,17 @@
+package com.example.paycheck.domain.workrecord.enums;
+
+public enum WorkRecordCurrentStatus {
+    IN_PROGRESS(0),
+    UPCOMING(1),
+    COMPLETED(2);
+
+    private final int sortOrder;
+
+    WorkRecordCurrentStatus(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+}

--- a/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
@@ -11,6 +11,7 @@ import com.example.paycheck.domain.worker.entity.Worker;
 import com.example.paycheck.domain.worker.repository.WorkerRepository;
 import com.example.paycheck.domain.workrecord.dto.WorkRecordDto;
 import com.example.paycheck.domain.workrecord.entity.WorkRecord;
+import com.example.paycheck.domain.workrecord.enums.WorkRecordCurrentStatus;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
 import com.example.paycheck.domain.workrecord.repository.WorkRecordRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +34,7 @@ public class WorkRecordQueryService {
     private final WorkRecordRepository workRecordRepository;
     private final WorkerRepository workerRepository;
     private final CorrectionRequestRepository correctionRequestRepository;
+    private final Clock clock;
 
     public List<WorkRecordDto.Response> getWorkRecordsByContract(Long contractId) {
         return workRecordRepository.findByContractId(contractId, WorkRecordStatus.DELETED).stream()
@@ -60,8 +64,11 @@ public class WorkRecordQueryService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.WORKER_NOT_FOUND, "근로자 정보를 찾을 수 없습니다."));
 
         List<WorkRecord> records = workRecordRepository.findByWorkerAndDateRange(worker.getId(), startDate, endDate, WorkRecordStatus.DELETED);
+        LocalDateTime now = LocalDateTime.now(clock);
+
         return records.stream()
-                .map(WorkRecordDto.DetailedResponse::from)
+                .sorted(buildWorkerRecordComparator(now))
+                .map(record -> WorkRecordDto.DetailedResponse.from(record, calculateCurrentStatus(record, now)))
                 .collect(Collectors.toList());
     }
 
@@ -86,5 +93,42 @@ public class WorkRecordQueryService {
                 .map(CorrectionRequestDto.ListResponse::from)
                 .sorted(Comparator.comparing(CorrectionRequestDto.ListResponse::getCreatedAt).reversed())
                 .collect(Collectors.toList());
+    }
+
+    private Comparator<WorkRecord> buildWorkerRecordComparator(LocalDateTime now) {
+        return Comparator
+                .comparing((WorkRecord record) -> calculateCurrentStatus(record, now).getSortOrder())
+                .thenComparing(this::getStartDateTime)
+                .thenComparing(WorkRecord::getId);
+    }
+
+    private WorkRecordCurrentStatus calculateCurrentStatus(WorkRecord workRecord, LocalDateTime now) {
+        if (workRecord.getStatus() == WorkRecordStatus.COMPLETED) {
+            return WorkRecordCurrentStatus.COMPLETED;
+        }
+
+        LocalDateTime startDateTime = getStartDateTime(workRecord);
+        LocalDateTime endDateTime = getEndDateTime(workRecord);
+
+        if (!now.isBefore(endDateTime)) {
+            return WorkRecordCurrentStatus.COMPLETED;
+        }
+
+        if (!now.isBefore(startDateTime)) {
+            return WorkRecordCurrentStatus.IN_PROGRESS;
+        }
+
+        return WorkRecordCurrentStatus.UPCOMING;
+    }
+
+    private LocalDateTime getStartDateTime(WorkRecord workRecord) {
+        return workRecord.getWorkDate().atTime(workRecord.getStartTime());
+    }
+
+    private LocalDateTime getEndDateTime(WorkRecord workRecord) {
+        LocalDate endDate = workRecord.getEndTime().isAfter(workRecord.getStartTime())
+                ? workRecord.getWorkDate()
+                : workRecord.getWorkDate().plusDays(1);
+        return endDate.atTime(workRecord.getEndTime());
     }
 }

--- a/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
@@ -98,8 +98,22 @@ public class WorkRecordQueryService {
     private Comparator<WorkRecord> buildWorkerRecordComparator(LocalDateTime now) {
         return Comparator
                 .comparing((WorkRecord record) -> calculateCurrentStatus(record, now).getSortOrder())
-                .thenComparing(this::getStartDateTime)
+                .thenComparing((left, right) -> compareWithinSameCurrentStatus(left, right, now))
                 .thenComparing(WorkRecord::getId);
+    }
+
+    private int compareWithinSameCurrentStatus(WorkRecord left, WorkRecord right, LocalDateTime now) {
+        WorkRecordCurrentStatus leftStatus = calculateCurrentStatus(left, now);
+        WorkRecordCurrentStatus rightStatus = calculateCurrentStatus(right, now);
+
+        if (leftStatus != rightStatus) {
+            return 0;
+        }
+
+        return switch (leftStatus) {
+            case IN_PROGRESS, UPCOMING -> getStartDateTime(left).compareTo(getStartDateTime(right));
+            case COMPLETED -> getEndDateTime(right).compareTo(getEndDateTime(left));
+        };
     }
 
     private WorkRecordCurrentStatus calculateCurrentStatus(WorkRecord workRecord, LocalDateTime now) {

--- a/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
@@ -152,6 +152,7 @@ public class WorkRecordQueryService {
                 ? workRecord.getWorkDate()
                 : workRecord.getWorkDate().plusDays(1);
         return endDate.atTime(workRecord.getEndTime());
+    }
     private List<LocalDate> getCalendarDisplayDates(WorkRecord workRecord, LocalDate startDate, LocalDate endDate) {
         List<LocalDate> displayDates = new ArrayList<>();
         LocalDate workDate = workRecord.getWorkDate();

--- a/src/test/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDtoTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDtoTest.java
@@ -4,6 +4,7 @@ import com.example.paycheck.domain.contract.entity.WorkerContract;
 import com.example.paycheck.domain.user.entity.User;
 import com.example.paycheck.domain.worker.entity.Worker;
 import com.example.paycheck.domain.workrecord.entity.WorkRecord;
+import com.example.paycheck.domain.workrecord.enums.WorkRecordCurrentStatus;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
 import com.example.paycheck.domain.workplace.entity.Workplace;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,6 +82,7 @@ class WorkRecordDtoTest {
         assertThat(response.getBreakMinutes()).isEqualTo(60);
         assertThat(response.getTotalWorkMinutes()).isEqualTo(480);
         assertThat(response.getStatus()).isEqualTo(WorkRecordStatus.COMPLETED);
+        assertThat(response.getCurrentStatus()).isEqualTo(WorkRecordCurrentStatus.COMPLETED);
         assertThat(response.getIsModified()).isFalse();
         assertThat(response.getMemo()).isEqualTo("테스트 메모");
 
@@ -111,6 +113,7 @@ class WorkRecordDtoTest {
 
         // then
         assertThat(response.getHourlyWage()).isEqualByComparingTo(BigDecimal.valueOf(10000));
+        assertThat(response.getCurrentStatus()).isEqualTo(WorkRecordCurrentStatus.UPCOMING);
         assertThat(response.getBaseSalary()).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(response.getNightSalary()).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(response.getHolidaySalary()).isEqualByComparingTo(BigDecimal.ZERO);

--- a/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryServiceTest.java
@@ -120,20 +120,28 @@ class WorkRecordQueryServiceTest {
     }
 
     @Test
-    @DisplayName("근로자 주간 근무 목록 조회 시 현재 상태 기준으로 정렬한다")
+    @DisplayName("근로자 주간 근무 목록 조회 시 진행중, 예정, 완료 순으로 정렬한다")
     void getWorkRecordsByWorkerAndDateRange_SortsByCurrentStatus() {
         // given
         Worker worker = mock(Worker.class);
         when(worker.getId()).thenReturn(1L);
         when(workerRepository.findByUserId(10L)).thenReturn(Optional.of(worker));
 
-        WorkRecord upcomingRecord = createWorkRecord(3L, LocalDate.of(2026, 2, 21), LocalTime.of(3, 0), LocalTime.of(7, 0), WorkRecordStatus.SCHEDULED);
-        WorkRecord completedRecord = createWorkRecord(2L, LocalDate.of(2026, 2, 20), LocalTime.of(20, 0), LocalTime.of(23, 0), WorkRecordStatus.SCHEDULED);
         WorkRecord inProgressRecord = createWorkRecord(1L, LocalDate.of(2026, 2, 20), LocalTime.of(22, 0), LocalTime.of(2, 0), WorkRecordStatus.SCHEDULED);
+        WorkRecord upcomingSoonRecord = createWorkRecord(3L, LocalDate.of(2026, 2, 21), LocalTime.of(3, 0), LocalTime.of(7, 0), WorkRecordStatus.SCHEDULED);
+        WorkRecord upcomingLaterRecord = createWorkRecord(4L, LocalDate.of(2026, 2, 21), LocalTime.of(6, 0), LocalTime.of(10, 0), WorkRecordStatus.SCHEDULED);
+        WorkRecord completedRecentRecord = createWorkRecord(2L, LocalDate.of(2026, 2, 20), LocalTime.of(20, 0), LocalTime.of(23, 0), WorkRecordStatus.SCHEDULED);
+        WorkRecord completedOldRecord = createWorkRecord(5L, LocalDate.of(2026, 2, 20), LocalTime.of(18, 0), LocalTime.of(20, 0), WorkRecordStatus.SCHEDULED);
 
         when(workRecordRepository.findByWorkerAndDateRange(
                 1L, LocalDate.of(2026, 2, 17), LocalDate.of(2026, 2, 23), WorkRecordStatus.DELETED))
-                .thenReturn(Arrays.asList(upcomingRecord, completedRecord, inProgressRecord));
+                .thenReturn(Arrays.asList(
+                        completedOldRecord,
+                        upcomingLaterRecord,
+                        completedRecentRecord,
+                        inProgressRecord,
+                        upcomingSoonRecord
+                ));
 
         // when
         List<WorkRecordDto.DetailedResponse> result = workRecordQueryService.getWorkRecordsByWorkerAndDateRange(
@@ -141,15 +149,19 @@ class WorkRecordQueryServiceTest {
 
         // then
         assertThat(result).extracting(WorkRecordDto.DetailedResponse::getId)
-                .containsExactly(1L, 3L, 2L);
+                .containsExactly(1L, 3L, 4L, 2L, 5L);
         assertThat(result).extracting(WorkRecordDto.DetailedResponse::getCurrentStatus)
                 .containsExactly(
                         WorkRecordCurrentStatus.IN_PROGRESS,
                         WorkRecordCurrentStatus.UPCOMING,
+                        WorkRecordCurrentStatus.UPCOMING,
+                        WorkRecordCurrentStatus.COMPLETED,
                         WorkRecordCurrentStatus.COMPLETED
                 );
         assertThat(result).extracting(WorkRecordDto.DetailedResponse::getStatus)
                 .containsExactly(
+                        WorkRecordStatus.SCHEDULED,
+                        WorkRecordStatus.SCHEDULED,
                         WorkRecordStatus.SCHEDULED,
                         WorkRecordStatus.SCHEDULED,
                         WorkRecordStatus.SCHEDULED

--- a/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryServiceTest.java
@@ -2,19 +2,30 @@ package com.example.paycheck.domain.workrecord.service;
 
 import com.example.paycheck.common.exception.NotFoundException;
 import com.example.paycheck.domain.correction.repository.CorrectionRequestRepository;
+import com.example.paycheck.domain.contract.entity.WorkerContract;
+import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.worker.entity.Worker;
 import com.example.paycheck.domain.worker.repository.WorkerRepository;
 import com.example.paycheck.domain.workrecord.dto.WorkRecordDto;
+import com.example.paycheck.domain.workrecord.entity.WorkRecord;
+import com.example.paycheck.domain.workrecord.enums.WorkRecordCurrentStatus;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
 import com.example.paycheck.domain.workrecord.repository.WorkRecordRepository;
+import com.example.paycheck.domain.workplace.entity.Workplace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +46,12 @@ class WorkRecordQueryServiceTest {
 
     @Mock
     private CorrectionRequestRepository correctionRequestRepository;
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-02-21T01:30:00Z"),
+            ZoneId.of("UTC")
+    );
 
     @InjectMocks
     private WorkRecordQueryService workRecordQueryService;
@@ -100,6 +117,95 @@ class WorkRecordQueryServiceTest {
         assertThatThrownBy(() -> workRecordQueryService.getWorkRecordsByWorkerAndDateRange(
                 1L, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31)))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("근로자 주간 근무 목록 조회 시 현재 상태 기준으로 정렬한다")
+    void getWorkRecordsByWorkerAndDateRange_SortsByCurrentStatus() {
+        // given
+        Worker worker = mock(Worker.class);
+        when(worker.getId()).thenReturn(1L);
+        when(workerRepository.findByUserId(10L)).thenReturn(Optional.of(worker));
+
+        WorkRecord upcomingRecord = createWorkRecord(3L, LocalDate.of(2026, 2, 21), LocalTime.of(3, 0), LocalTime.of(7, 0), WorkRecordStatus.SCHEDULED);
+        WorkRecord completedRecord = createWorkRecord(2L, LocalDate.of(2026, 2, 20), LocalTime.of(20, 0), LocalTime.of(23, 0), WorkRecordStatus.SCHEDULED);
+        WorkRecord inProgressRecord = createWorkRecord(1L, LocalDate.of(2026, 2, 20), LocalTime.of(22, 0), LocalTime.of(2, 0), WorkRecordStatus.SCHEDULED);
+
+        when(workRecordRepository.findByWorkerAndDateRange(
+                1L, LocalDate.of(2026, 2, 17), LocalDate.of(2026, 2, 23), WorkRecordStatus.DELETED))
+                .thenReturn(Arrays.asList(upcomingRecord, completedRecord, inProgressRecord));
+
+        // when
+        List<WorkRecordDto.DetailedResponse> result = workRecordQueryService.getWorkRecordsByWorkerAndDateRange(
+                10L, LocalDate.of(2026, 2, 17), LocalDate.of(2026, 2, 23));
+
+        // then
+        assertThat(result).extracting(WorkRecordDto.DetailedResponse::getId)
+                .containsExactly(1L, 3L, 2L);
+        assertThat(result).extracting(WorkRecordDto.DetailedResponse::getCurrentStatus)
+                .containsExactly(
+                        WorkRecordCurrentStatus.IN_PROGRESS,
+                        WorkRecordCurrentStatus.UPCOMING,
+                        WorkRecordCurrentStatus.COMPLETED
+                );
+        assertThat(result).extracting(WorkRecordDto.DetailedResponse::getStatus)
+                .containsExactly(
+                        WorkRecordStatus.SCHEDULED,
+                        WorkRecordStatus.SCHEDULED,
+                        WorkRecordStatus.SCHEDULED
+                );
+    }
+
+    @Test
+    @DisplayName("완료 상태 근무는 현재 시점과 무관하게 완료로 유지한다")
+    void getWorkRecordsByWorkerAndDateRange_KeepsCompletedStatus() {
+        // given
+        Worker worker = mock(Worker.class);
+        when(worker.getId()).thenReturn(1L);
+        when(workerRepository.findByUserId(10L)).thenReturn(Optional.of(worker));
+
+        WorkRecord completedRecord = createWorkRecord(11L, LocalDate.of(2026, 2, 21), LocalTime.of(3, 0), LocalTime.of(7, 0), WorkRecordStatus.COMPLETED);
+
+        when(workRecordRepository.findByWorkerAndDateRange(
+                1L, LocalDate.of(2026, 2, 21), LocalDate.of(2026, 2, 21), WorkRecordStatus.DELETED))
+                .thenReturn(List.of(completedRecord));
+
+        // when
+        List<WorkRecordDto.DetailedResponse> result = workRecordQueryService.getWorkRecordsByWorkerAndDateRange(
+                10L, LocalDate.of(2026, 2, 21), LocalDate.of(2026, 2, 21));
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCurrentStatus()).isEqualTo(WorkRecordCurrentStatus.COMPLETED);
+        assertThat(result.get(0).getStatus()).isEqualTo(WorkRecordStatus.COMPLETED);
+    }
+
+    private WorkRecord createWorkRecord(Long id, LocalDate workDate, LocalTime startTime, LocalTime endTime, WorkRecordStatus status) {
+        User user = mock(User.class);
+        when(user.getName()).thenReturn("근로자");
+
+        Worker worker = mock(Worker.class);
+        when(worker.getUser()).thenReturn(user);
+        lenient().when(worker.getWorkerCode()).thenReturn("WORKER001");
+
+        Workplace workplace = mock(Workplace.class);
+        when(workplace.getName()).thenReturn("테스트 사업장");
+
+        WorkerContract contract = mock(WorkerContract.class);
+        when(contract.getId()).thenReturn(100L);
+        when(contract.getWorker()).thenReturn(worker);
+        when(contract.getWorkplace()).thenReturn(workplace);
+
+        return WorkRecord.builder()
+                .id(id)
+                .contract(contract)
+                .workDate(workDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .breakMinutes(60)
+                .status(status)
+                .isModified(false)
+                .build();
     }
 
 }


### PR DESCRIPTION
완료

## 변경 사항
- 근로자 주간 근무 목록에 현재 상태(IN_PROGRESS/UPCOMING/COMPLETED)를 계산해 노출하도록 수정했습니다.
- 현재 상태 기준 정렬이 적용되도록 근무 목록 정렬 로직을 보완했습니다.

## 테스트
- ./gradlew test --tests 'com.example.paycheck.domain.workrecord.service.WorkRecordQueryServiceTest' --tests 'com.example.paycheck.domain.workrecord.dto.WorkRecordDtoTest'