### PR TITLE
[bug] 프로필 이미지 업로드 및 조회 오류 수정

### DIFF
--- a/src/main/java/com/example/paycheck/api/user/UserController.java
+++ b/src/main/java/com/example/paycheck/api/user/UserController.java
@@ -14,8 +14,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "사용자", description = "사용자 정보 조회 및 관리 API")
@@ -48,6 +50,15 @@ public class UserController {
             @AuthenticationPrincipal User user,
             @Valid @RequestBody UserDto.UpdateRequest request) {
         return ApiResponse.success(userService.updateUser(user.getId(), request));
+    }
+
+    @Operation(summary = "내 프로필 이미지 업로드", description = "로그인한 사용자의 프로필 이미지를 업로드합니다.")
+    @PostMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<UserDto.Response> uploadMyProfileImage(
+            @AuthenticationPrincipal User user,
+            @Parameter(description = "프로필 이미지 파일", required = true)
+            @RequestPart("file") MultipartFile file) {
+        return ApiResponse.success(userService.updateProfileImage(user.getId(), file));
     }
 
     @Operation(summary = "계좌 정보 수정 (근로자 전용)", description = "로그인한 근로자의 계좌 정보를 수정합니다.")

--- a/src/main/java/com/example/paycheck/domain/user/dto/UserDto.java
+++ b/src/main/java/com/example/paycheck/domain/user/dto/UserDto.java
@@ -32,24 +32,32 @@ public class UserDto {
         private String accountNumber;
 
         public static Response from(User user) {
+            return from(user, user.getProfileImageUrl());
+        }
+
+        public static Response from(User user, String profileImageUrl) {
             return Response.builder()
                     .id(user.getId())
                     .kakaoId(user.getKakaoId())
                     .name(user.getName())
                     .phone(user.getPhone())
                     .userType(user.getUserType())
-                    .profileImageUrl(user.getProfileImageUrl())
+                    .profileImageUrl(profileImageUrl)
                     .build();
         }
 
         public static Response from(User user, Worker worker) {
+            return from(user, worker, user.getProfileImageUrl());
+        }
+
+        public static Response from(User user, Worker worker, String profileImageUrl) {
             return Response.builder()
                     .id(user.getId())
                     .kakaoId(user.getKakaoId())
                     .name(user.getName())
                     .phone(user.getPhone())
                     .userType(user.getUserType())
-                    .profileImageUrl(user.getProfileImageUrl())
+                    .profileImageUrl(profileImageUrl)
                     .workerCode(worker.getWorkerCode())
                     .bankName(worker.getBankName())
                     .accountNumber(worker.getAccountNumber())
@@ -69,7 +77,7 @@ public class UserDto {
         @Pattern(regexp = "^01[0-9]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
         private String phone;
 
-        @Pattern(regexp = "^(https?://.+)?$", message = "프로필 이미지는 HTTP/HTTPS URL 형식이어야 합니다.")
+        @Pattern(regexp = "^(https?://.+|/.+)?$", message = "프로필 이미지는 HTTP/HTTPS URL 또는 서버 이미지 경로 형식이어야 합니다.")
         private String profileImageUrl;
     }
 

--- a/src/main/java/com/example/paycheck/domain/user/service/ProfileImageStorageService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/ProfileImageStorageService.java
@@ -1,0 +1,112 @@
+package com.example.paycheck.domain.user.service;
+
+import com.example.paycheck.common.exception.BadRequestException;
+import com.example.paycheck.common.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class ProfileImageStorageService {
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+
+    private final Path profileImageDirectory;
+    private final String publicUriPrefix;
+
+    public ProfileImageStorageService(
+            @Value("${app.upload.profile-image-dir:uploads/profile-images}") String profileImageDirectory,
+            @Value("${app.upload.profile-image-uri-prefix:/uploads/profile-images/}") String publicUriPrefix) {
+        this.profileImageDirectory = Paths.get(profileImageDirectory).toAbsolutePath().normalize();
+        this.publicUriPrefix = normalizePublicUriPrefix(publicUriPrefix);
+    }
+
+    public String store(MultipartFile file) {
+        validate(file);
+
+        try {
+            Files.createDirectories(profileImageDirectory);
+
+            String extension = extractExtension(file.getOriginalFilename());
+            String storedFileName = UUID.randomUUID() + "." + extension;
+            Path targetPath = profileImageDirectory.resolve(storedFileName).normalize();
+
+            file.transferTo(targetPath);
+            return publicUriPrefix + storedFileName;
+        } catch (IOException e) {
+            throw new IllegalStateException("프로필 이미지를 저장할 수 없습니다.", e);
+        }
+    }
+
+    public void deleteIfStoredLocally(String profileImageUrl) {
+        if (!StringUtils.hasText(profileImageUrl) || !profileImageUrl.startsWith(publicUriPrefix)) {
+            return;
+        }
+
+        String fileName = profileImageUrl.substring(publicUriPrefix.length());
+        if (!StringUtils.hasText(fileName)) {
+            return;
+        }
+
+        try {
+            Files.deleteIfExists(profileImageDirectory.resolve(fileName).normalize());
+        } catch (IOException ignored) {
+            // 이전 프로필 이미지 정리에 실패해도 업로드 성공 흐름은 유지한다.
+        }
+    }
+
+    public Path getProfileImageDirectory() {
+        return profileImageDirectory;
+    }
+
+    public String getPublicUriPrefix() {
+        return publicUriPrefix;
+    }
+
+    private void validate(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE, "업로드할 프로필 이미지 파일이 필요합니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (!StringUtils.hasText(contentType) || !contentType.startsWith("image/")) {
+            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE, "이미지 파일만 업로드할 수 있습니다.");
+        }
+
+        extractExtension(file.getOriginalFilename());
+    }
+
+    private String extractExtension(String originalFilename) {
+        String extension = StringUtils.getFilenameExtension(originalFilename);
+        if (!StringUtils.hasText(extension)) {
+            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 이미지 형식입니다.");
+        }
+
+        String normalizedExtension = extension.toLowerCase(Locale.ROOT);
+        if (!ALLOWED_EXTENSIONS.contains(normalizedExtension)) {
+            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 이미지 형식입니다.");
+        }
+
+        return normalizedExtension;
+    }
+
+    private String normalizePublicUriPrefix(String publicUriPrefix) {
+        String normalized = StringUtils.hasText(publicUriPrefix) ? publicUriPrefix.trim() : "/uploads/profile-images/";
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        if (!normalized.endsWith("/")) {
+            normalized = normalized + "/";
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/com/example/paycheck/domain/user/service/ProfileImageUrlResolver.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/ProfileImageUrlResolver.java
@@ -1,0 +1,31 @@
+package com.example.paycheck.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Service
+public class ProfileImageUrlResolver {
+
+    public String resolve(String profileImageUrl) {
+        if (!StringUtils.hasText(profileImageUrl)) {
+            return profileImageUrl;
+        }
+
+        if (profileImageUrl.startsWith("http://") || profileImageUrl.startsWith("https://")) {
+            return profileImageUrl;
+        }
+
+        if (!profileImageUrl.startsWith("/")) {
+            return profileImageUrl;
+        }
+
+        try {
+            return ServletUriComponentsBuilder.fromCurrentContextPath()
+                    .path(profileImageUrl)
+                    .toUriString();
+        } catch (IllegalStateException e) {
+            return profileImageUrl;
+        }
+    }
+}

--- a/src/main/java/com/example/paycheck/domain/user/service/UserService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserService.java
@@ -68,16 +68,6 @@ public class UserService {
     }
 
     @Transactional
-    public UserDto.ProfileImageUploadResponse uploadProfileImage(Long userId, MultipartFile file) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
-
-        String profileImageUrl = profileImageStorageService.uploadProfileImage(userId, file);
-        user.updateProfileImage(profileImageUrl);
-        return UserDto.ProfileImageUploadResponse.from(profileImageUrl);
-    }
-
-    @Transactional
     public UserDto.RegisterResponse register(UserDto.RegisterRequest request) {
         // User 생성
         User user = User.builder()

--- a/src/main/java/com/example/paycheck/domain/user/service/UserService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import com.example.paycheck.domain.worker.service.WorkerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +26,8 @@ public class UserService {
     private final WorkerService workerService;
     private final EmployerService employerService;
     private final UserSettingsService userSettingsService;
+    private final ProfileImageStorageService profileImageStorageService;
+    private final ProfileImageUrlResolver profileImageUrlResolver;
 
     public UserDto.Response getUserById(Long userId) {
         User user = userRepository.findById(userId)
@@ -32,10 +35,10 @@ public class UserService {
 
         if (user.getUserType() == UserType.WORKER) {
             return workerRepository.findByUserId(userId)
-                    .map(worker -> UserDto.Response.from(user, worker))
-                    .orElse(UserDto.Response.from(user));
+                    .map(worker -> buildUserResponse(user, worker))
+                    .orElse(buildUserResponse(user));
         }
-        return UserDto.Response.from(user);
+        return buildUserResponse(user);
     }
 
     @Transactional
@@ -45,7 +48,23 @@ public class UserService {
 
         user.updateProfile(request.getName(), request.getPhone(), request.getProfileImageUrl());
 
-        return UserDto.Response.from(user);
+        return getUserById(userId);
+    }
+
+    @Transactional
+    public UserDto.Response updateProfileImage(Long userId, MultipartFile profileImage) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        String previousProfileImageUrl = user.getProfileImageUrl();
+        String storedProfileImageUrl = profileImageStorageService.store(profileImage);
+        user.updateProfile(null, null, storedProfileImageUrl);
+
+        if (previousProfileImageUrl != null && !previousProfileImageUrl.equals(storedProfileImageUrl)) {
+            profileImageStorageService.deleteIfStoredLocally(previousProfileImageUrl);
+        }
+
+        return getUserById(userId);
     }
 
     @Transactional
@@ -75,5 +94,13 @@ public class UserService {
         }
 
         return UserDto.RegisterResponse.from(savedUser, workerCode);
+    }
+
+    private UserDto.Response buildUserResponse(User user) {
+        return UserDto.Response.from(user, profileImageUrlResolver.resolve(user.getProfileImageUrl()));
+    }
+
+    private UserDto.Response buildUserResponse(User user, Worker worker) {
+        return UserDto.Response.from(user, worker, profileImageUrlResolver.resolve(user.getProfileImageUrl()));
     }
 }

--- a/src/main/java/com/example/paycheck/global/config/WebMvcConfig.java
+++ b/src/main/java/com/example/paycheck/global/config/WebMvcConfig.java
@@ -1,6 +1,7 @@
 package com.example.paycheck.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
@@ -13,8 +14,10 @@ import org.springframework.web.servlet.config.annotation.ContentNegotiationConfi
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -33,9 +36,16 @@ import java.util.List;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final ObjectMapper objectMapper;
+    private final String profileImageDirectory;
+    private final String profileImageUriPrefix;
 
-    public WebMvcConfig(ObjectMapper objectMapper) {
+    public WebMvcConfig(
+            ObjectMapper objectMapper,
+            @Value("${app.upload.profile-image-dir:uploads/profile-images}") String profileImageDirectory,
+            @Value("${app.upload.profile-image-uri-prefix:/uploads/profile-images/}") String profileImageUriPrefix) {
         this.objectMapper = objectMapper;
+        this.profileImageDirectory = profileImageDirectory;
+        this.profileImageUriPrefix = normalizeUriPrefix(profileImageUriPrefix);
     }
 
     @Override
@@ -68,5 +78,27 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
         // XML 컨버터는 의도적으로 추가하지 않음
         // jackson-dataformat-xml은 RestTemplate에서 공공 API XML 응답 파싱에만 사용
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String resourceLocation = Paths.get(profileImageDirectory).toAbsolutePath().normalize().toUri().toString();
+        if (!resourceLocation.endsWith("/")) {
+            resourceLocation = resourceLocation + "/";
+        }
+
+        registry.addResourceHandler(profileImageUriPrefix + "**")
+                .addResourceLocations(resourceLocation);
+    }
+
+    private String normalizeUriPrefix(String uriPrefix) {
+        String normalized = uriPrefix;
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        if (!normalized.endsWith("/")) {
+            normalized = normalized + "/";
+        }
+        return normalized;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,6 +62,10 @@ cookie.same-site=Lax
 # CORS Configuration (환경별 오버라이드 가능)
 cors.allowed-origins=http://localhost:3000,http://localhost:5173
 
+# Profile Image Upload Configuration
+app.upload.profile-image-dir=${APP_UPLOAD_PROFILE_IMAGE_DIR:uploads/profile-images}
+app.upload.profile-image-uri-prefix=${APP_UPLOAD_PROFILE_IMAGE_URI_PREFIX:/uploads/profile-images/}
+
 # Encryption Configuration (개발용 키 - 프로덕션에서는 반드시 환경변수 사용)
 encryption.aes-key=IuQq5A+rPiWgKR/qdPd3TOugPl1oVW67AUMxctc81hg=
 

--- a/src/test/java/com/example/paycheck/api/user/UserControllerTest.java
+++ b/src/test/java/com/example/paycheck/api/user/UserControllerTest.java
@@ -78,16 +78,14 @@ class UserControllerTest {
                 "image-content".getBytes()
         );
 
-        given(userService.uploadProfileImage(eq(1L), any()))
-                .willReturn(UserDto.ProfileImageUploadResponse.from(
-                        "https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png"
-                ));
+        String resolvedUrl = "http://localhost/uploads/profile-images/uuid-profile.png";
+
+        given(userService.updateProfileImage(eq(1L), any()))
+                .willReturn(UserDto.Response.from(testUser, resolvedUrl));
 
         mockMvc.perform(multipart("/api/users/me/profile-image").file(file))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.profileImageUrl").value(
-                        "https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png"
-                ));
+                .andExpect(jsonPath("$.data.profileImageUrl").value(resolvedUrl));
     }
 }

--- a/src/test/java/com/example/paycheck/domain/user/service/ProfileImageStorageServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/ProfileImageStorageServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.paycheck.domain.user.service;
+
+import com.example.paycheck.common.exception.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ProfileImageStorageService 테스트")
+class ProfileImageStorageServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("프로필 이미지를 저장하고 공개 경로를 반환한다")
+    void store_Success() throws Exception {
+        ProfileImageStorageService storageService = new ProfileImageStorageService(
+                tempDir.resolve("profile-images").toString(),
+                "/uploads/profile-images/"
+        );
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "avatar.png",
+                "image/png",
+                "image-bytes".getBytes()
+        );
+
+        String storedPath = storageService.store(file);
+
+        assertThat(storedPath).startsWith("/uploads/profile-images/");
+        try (var storedFiles = Files.list(storageService.getProfileImageDirectory())) {
+            assertThat(storedFiles.count()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 파일은 업로드할 수 없다")
+    void store_Fail_InvalidContentType() {
+        ProfileImageStorageService storageService = new ProfileImageStorageService(
+                tempDir.resolve("profile-images").toString(),
+                "/uploads/profile-images/"
+        );
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "avatar.txt",
+                "text/plain",
+                "not-image".getBytes()
+        );
+
+        assertThatThrownBy(() -> storageService.store(file))
+                .isInstanceOf(BadRequestException.class);
+    }
+}

--- a/src/test/java/com/example/paycheck/domain/user/service/ProfileImageUrlResolverTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/ProfileImageUrlResolverTest.java
@@ -1,0 +1,44 @@
+package com.example.paycheck.domain.user.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ProfileImageUrlResolver 테스트")
+class ProfileImageUrlResolverTest {
+
+    private final ProfileImageUrlResolver resolver = new ProfileImageUrlResolver();
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("상대 경로 프로필 이미지를 현재 서버 기준 절대 URL로 변환한다")
+    void resolve_RelativePathToAbsoluteUrl() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.setServerName("api.example.com");
+        request.setServerPort(443);
+        request.setContextPath("");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String resolved = resolver.resolve("/uploads/profile-images/avatar.png");
+
+        assertThat(resolved).isEqualTo("https://api.example.com/uploads/profile-images/avatar.png");
+    }
+
+    @Test
+    @DisplayName("이미 절대 URL이면 그대로 반환한다")
+    void resolve_AbsoluteUrl() {
+        String resolved = resolver.resolve("https://cdn.example.com/avatar.png");
+
+        assertThat(resolved).isEqualTo("https://cdn.example.com/avatar.png");
+    }
+}

--- a/src/test/java/com/example/paycheck/domain/user/service/UserServiceSimpleTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserServiceSimpleTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.Optional;
 
@@ -41,6 +42,12 @@ class UserServiceSimpleTest {
 
     @Mock
     private UserSettingsService userSettingsService;
+
+    @Mock
+    private ProfileImageStorageService profileImageStorageService;
+
+    @Mock
+    private ProfileImageUrlResolver profileImageUrlResolver;
 
     @InjectMocks
     private UserService userService;
@@ -72,6 +79,8 @@ class UserServiceSimpleTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(testWorker));
         when(workerRepository.findByUserId(1L)).thenReturn(Optional.of(mockWorker));
+        when(profileImageUrlResolver.resolve("https://example.com/worker.jpg"))
+                .thenReturn("https://example.com/worker.jpg");
 
         // when
         UserDto.Response result = userService.getUserById(1L);
@@ -81,6 +90,7 @@ class UserServiceSimpleTest {
         assertThat(result.getId()).isEqualTo(1L);
         assertThat(result.getName()).isEqualTo("근로자 테스트");
         assertThat(result.getUserType()).isEqualTo(UserType.WORKER);
+        assertThat(result.getProfileImageUrl()).isEqualTo("https://example.com/worker.jpg");
         assertThat(result.getWorkerCode()).isEqualTo("ABC123");
         assertThat(result.getBankName()).isEqualTo("카카오뱅크");
         assertThat(result.getAccountNumber()).isEqualTo("123456789012");
@@ -114,13 +124,17 @@ class UserServiceSimpleTest {
                 .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(testWorker));
+        when(workerRepository.findByUserId(1L)).thenReturn(Optional.of(Worker.builder().user(testWorker).build()));
+        when(profileImageUrlResolver.resolve("https://example.com/new_profile.jpg"))
+                .thenReturn("https://example.com/new_profile.jpg");
 
         // when
         UserDto.Response result = userService.updateUser(1L, request);
 
         // then
         assertThat(result).isNotNull();
-        verify(userRepository).findById(1L);
+        assertThat(result.getProfileImageUrl()).isEqualTo("https://example.com/new_profile.jpg");
+        verify(userRepository, times(2)).findById(1L);
     }
 
     @Test
@@ -136,5 +150,31 @@ class UserServiceSimpleTest {
         // when & then
         assertThatThrownBy(() -> userService.updateUser(999L, request))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 성공")
+    void updateProfileImage_Success() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "image".getBytes()
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testWorker));
+        when(workerRepository.findByUserId(1L)).thenReturn(Optional.of(Worker.builder().user(testWorker).build()));
+        when(profileImageStorageService.store(file)).thenReturn("/uploads/profile-images/new-profile.png");
+        when(profileImageUrlResolver.resolve("/uploads/profile-images/new-profile.png"))
+                .thenReturn("http://localhost:8080/uploads/profile-images/new-profile.png");
+
+        // when
+        UserDto.Response result = userService.updateProfileImage(1L, file);
+
+        // then
+        assertThat(result.getProfileImageUrl()).isEqualTo("http://localhost:8080/uploads/profile-images/new-profile.png");
+        verify(profileImageStorageService).store(file);
+        verify(profileImageStorageService).deleteIfStoredLocally("https://example.com/worker.jpg");
     }
 }

--- a/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
@@ -100,7 +100,7 @@ class UserServiceTest {
 
     @Test
     @DisplayName("프로필 이미지 업로드 성공")
-    void uploadProfileImage_Success() {
+    void updateProfileImage_Success() {
         // given
         MockMultipartFile file = new MockMultipartFile(
                 "file",
@@ -108,20 +108,31 @@ class UserServiceTest {
                 "image/png",
                 "image-content".getBytes()
         );
-        String uploadedUrl = "https://test-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/profile.png";
+        String storedUrl = "/uploads/profile-images/uuid-profile.png";
+        String resolvedUrl = "http://localhost/uploads/profile-images/uuid-profile.png";
+
+        Worker worker = Worker.builder()
+                .workerCode("WRK001")
+                .bankName("카카오뱅크")
+                .accountNumber("123456789012")
+                .user(testUser)
+                .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(profileImageStorageService.uploadProfileImage(1L, file)).thenReturn(uploadedUrl);
+        when(workerRepository.findByUserId(1L)).thenReturn(Optional.of(worker));
+        when(profileImageStorageService.store(file)).thenReturn(storedUrl);
+        when(profileImageUrlResolver.resolve(storedUrl)).thenReturn(resolvedUrl);
 
         // when
-        UserDto.ProfileImageUploadResponse result = userService.uploadProfileImage(1L, file);
+        UserDto.Response result = userService.updateProfileImage(1L, file);
 
         // then
         assertThat(result).isNotNull();
-        assertThat(result.getProfileImageUrl()).isEqualTo(uploadedUrl);
-        assertThat(testUser.getProfileImageUrl()).isEqualTo(uploadedUrl);
-        verify(userRepository).findById(1L);
-        verify(profileImageStorageService).uploadProfileImage(1L, file);
+        assertThat(result.getProfileImageUrl()).isEqualTo(resolvedUrl);
+        assertThat(testUser.getProfileImageUrl()).isEqualTo(storedUrl);
+        verify(userRepository, times(2)).findById(1L);
+        verify(profileImageStorageService).store(file);
+        verify(profileImageStorageService, never()).deleteIfStoredLocally(any());
     }
 
     @Test

--- a/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserServiceTest.java
@@ -45,6 +45,12 @@ class UserServiceTest {
     @Mock
     private UserSettingsService userSettingsService;
 
+    @Mock
+    private ProfileImageStorageService profileImageStorageService;
+
+    @Mock
+    private ProfileImageUrlResolver profileImageUrlResolver;
+
     @InjectMocks
     private UserService userService;
 


### PR DESCRIPTION
## 변경 사항
- 내 프로필 이미지 업로드 API를 추가했습니다.
- 로컬 저장, 정적 서빙, 응답 URL 해석 로직을 추가해 업로드 후 조회가 가능하도록 수정했습니다.
- 프로필 이미지 URL 검증 규칙을 서버 경로까지 허용하도록 보완했습니다.

## 테스트
- ./gradlew test --tests 'com.example.paycheck.domain.user.service.ProfileImageStorageServiceTest' --tests 'com.example.paycheck.domain.user.service.ProfileImageUrlResolverTest' --tests 'com.example.paycheck.domain.user.service.UserServiceTest' --tests 'com.example.paycheck.domain.user.service.UserServiceSimpleTest'