### PR TITLE
[bug] 고용주 타임라인 익일 근무 표시 오류 수정

### DIFF
--- a/src/main/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDto.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/dto/WorkRecordDto.java
@@ -137,12 +137,16 @@ public class WorkRecordDto {
         private WorkRecordStatus status;
 
         public static CalendarResponse from(WorkRecord workRecord) {
+            return from(workRecord, workRecord.getWorkDate());
+        }
+
+        public static CalendarResponse from(WorkRecord workRecord, LocalDate displayDate) {
             return CalendarResponse.builder()
                     .id(workRecord.getId())
                     .contractId(workRecord.getContract().getId())
                     .workerName(workRecord.getContract().getWorker().getUser().getName())
                     .workplaceName(workRecord.getContract().getWorkplace().getName())
-                    .workDate(workRecord.getWorkDate())
+                    .workDate(displayDate)
                     .startTime(workRecord.getStartTime())
                     .endTime(workRecord.getEndTime())
                     .breakMinutes(workRecord.getBreakMinutes())

--- a/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,9 +48,16 @@ public class WorkRecordQueryService {
     // 고용주용: 사업장의 근무 기록 조회 (캘린더)
     public List<WorkRecordDto.CalendarResponse> getWorkRecordsByWorkplaceAndDateRange(
             Long workplaceId, LocalDate startDate, LocalDate endDate) {
-        List<WorkRecord> records = workRecordRepository.findByWorkplaceAndDateRange(workplaceId, startDate, endDate, WorkRecordStatus.DELETED);
+        LocalDate queryStartDate = startDate.minusDays(1);
+        List<WorkRecord> records = workRecordRepository.findByWorkplaceAndDateRange(
+                workplaceId, queryStartDate, endDate, WorkRecordStatus.DELETED);
+
         return records.stream()
-                .map(WorkRecordDto.CalendarResponse::from)
+                .flatMap(record -> getCalendarDisplayDates(record, startDate, endDate).stream()
+                        .map(displayDate -> WorkRecordDto.CalendarResponse.from(record, displayDate)))
+                .sorted(Comparator.comparing(WorkRecordDto.CalendarResponse::getWorkDate)
+                        .thenComparing(WorkRecordDto.CalendarResponse::getStartTime)
+                        .thenComparing(WorkRecordDto.CalendarResponse::getId))
                 .collect(Collectors.toList());
     }
 
@@ -86,5 +94,31 @@ public class WorkRecordQueryService {
                 .map(CorrectionRequestDto.ListResponse::from)
                 .sorted(Comparator.comparing(CorrectionRequestDto.ListResponse::getCreatedAt).reversed())
                 .collect(Collectors.toList());
+    }
+
+    private List<LocalDate> getCalendarDisplayDates(WorkRecord workRecord, LocalDate startDate, LocalDate endDate) {
+        List<LocalDate> displayDates = new ArrayList<>();
+        LocalDate workDate = workRecord.getWorkDate();
+
+        if (isWithinDateRange(workDate, startDate, endDate)) {
+            displayDates.add(workDate);
+        }
+
+        if (isOvernight(workRecord)) {
+            LocalDate nextDate = workDate.plusDays(1);
+            if (isWithinDateRange(nextDate, startDate, endDate)) {
+                displayDates.add(nextDate);
+            }
+        }
+
+        return displayDates;
+    }
+
+    private boolean isWithinDateRange(LocalDate date, LocalDate startDate, LocalDate endDate) {
+        return !date.isBefore(startDate) && !date.isAfter(endDate);
+    }
+
+    private boolean isOvernight(WorkRecord workRecord) {
+        return !workRecord.getEndTime().isAfter(workRecord.getStartTime());
     }
 }

--- a/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordQueryServiceTest.java
@@ -2,10 +2,15 @@ package com.example.paycheck.domain.workrecord.service;
 
 import com.example.paycheck.common.exception.NotFoundException;
 import com.example.paycheck.domain.correction.repository.CorrectionRequestRepository;
+import com.example.paycheck.domain.contract.entity.WorkerContract;
+import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.worker.entity.Worker;
 import com.example.paycheck.domain.worker.repository.WorkerRepository;
 import com.example.paycheck.domain.workrecord.dto.WorkRecordDto;
+import com.example.paycheck.domain.workrecord.entity.WorkRecord;
 import com.example.paycheck.domain.workrecord.enums.WorkRecordStatus;
 import com.example.paycheck.domain.workrecord.repository.WorkRecordRepository;
+import com.example.paycheck.domain.workplace.entity.Workplace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +84,7 @@ class WorkRecordQueryServiceTest {
         Long workplaceId = 1L;
         LocalDate startDate = LocalDate.of(2024, 1, 1);
         LocalDate endDate = LocalDate.of(2024, 1, 31);
-        when(workRecordRepository.findByWorkplaceAndDateRange(workplaceId, startDate, endDate, WorkRecordStatus.DELETED))
+        when(workRecordRepository.findByWorkplaceAndDateRange(workplaceId, startDate.minusDays(1), endDate, WorkRecordStatus.DELETED))
                 .thenReturn(Arrays.asList());
 
         // when
@@ -87,7 +93,69 @@ class WorkRecordQueryServiceTest {
 
         // then
         assertThat(result).isNotNull();
-        verify(workRecordRepository).findByWorkplaceAndDateRange(workplaceId, startDate, endDate, WorkRecordStatus.DELETED);
+        verify(workRecordRepository).findByWorkplaceAndDateRange(workplaceId, startDate.minusDays(1), endDate, WorkRecordStatus.DELETED);
+    }
+
+    @Test
+    @DisplayName("익일 근무는 종료일만 조회해도 타임라인에 표시된다")
+    void getWorkRecordsByWorkplaceAndDateRange_IncludesOvernightRecordOnEndDate() {
+        // given
+        Long workplaceId = 1L;
+        LocalDate startDate = LocalDate.of(2026, 3, 6);
+        LocalDate endDate = LocalDate.of(2026, 3, 6);
+        WorkRecord overnightRecord = createWorkRecord(
+                1L,
+                LocalDate.of(2026, 3, 5),
+                LocalTime.of(23, 0),
+                LocalTime.of(2, 0),
+                WorkRecordStatus.SCHEDULED
+        );
+
+        when(workRecordRepository.findByWorkplaceAndDateRange(
+                workplaceId, startDate.minusDays(1), endDate, WorkRecordStatus.DELETED))
+                .thenReturn(List.of(overnightRecord));
+
+        // when
+        List<WorkRecordDto.CalendarResponse> result = workRecordQueryService
+                .getWorkRecordsByWorkplaceAndDateRange(workplaceId, startDate, endDate);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(0).getWorkDate()).isEqualTo(LocalDate.of(2026, 3, 6));
+        verify(workRecordRepository).findByWorkplaceAndDateRange(
+                workplaceId, startDate.minusDays(1), endDate, WorkRecordStatus.DELETED);
+    }
+
+    @Test
+    @DisplayName("익일 근무는 시작일과 종료일 모두 타임라인에 매핑된다")
+    void getWorkRecordsByWorkplaceAndDateRange_MapsOvernightRecordToBothDays() {
+        // given
+        Long workplaceId = 1L;
+        LocalDate startDate = LocalDate.of(2026, 3, 5);
+        LocalDate endDate = LocalDate.of(2026, 3, 6);
+        WorkRecord overnightRecord = createWorkRecord(
+                1L,
+                LocalDate.of(2026, 3, 5),
+                LocalTime.of(23, 0),
+                LocalTime.of(2, 0),
+                WorkRecordStatus.SCHEDULED
+        );
+
+        when(workRecordRepository.findByWorkplaceAndDateRange(
+                workplaceId, startDate.minusDays(1), endDate, WorkRecordStatus.DELETED))
+                .thenReturn(List.of(overnightRecord));
+
+        // when
+        List<WorkRecordDto.CalendarResponse> result = workRecordQueryService
+                .getWorkRecordsByWorkplaceAndDateRange(workplaceId, startDate, endDate);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(WorkRecordDto.CalendarResponse::getWorkDate)
+                .containsExactly(LocalDate.of(2026, 3, 5), LocalDate.of(2026, 3, 6));
+        assertThat(result).extracting(WorkRecordDto.CalendarResponse::getId)
+                .containsExactly(1L, 1L);
     }
 
     @Test
@@ -100,6 +168,34 @@ class WorkRecordQueryServiceTest {
         assertThatThrownBy(() -> workRecordQueryService.getWorkRecordsByWorkerAndDateRange(
                 1L, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31)))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    private WorkRecord createWorkRecord(Long id, LocalDate workDate, LocalTime startTime, LocalTime endTime, WorkRecordStatus status) {
+        User user = mock(User.class);
+        when(user.getName()).thenReturn("근로자");
+
+        Worker worker = mock(Worker.class);
+        when(worker.getUser()).thenReturn(user);
+        lenient().when(worker.getWorkerCode()).thenReturn("WORKER001");
+
+        Workplace workplace = mock(Workplace.class);
+        when(workplace.getName()).thenReturn("테스트 사업장");
+
+        WorkerContract contract = mock(WorkerContract.class);
+        when(contract.getId()).thenReturn(100L);
+        when(contract.getWorker()).thenReturn(worker);
+        when(contract.getWorkplace()).thenReturn(workplace);
+
+        return WorkRecord.builder()
+                .id(id)
+                .contract(contract)
+                .workDate(workDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .breakMinutes(60)
+                .status(status)
+                .isModified(false)
+                .build();
     }
 
 }


### PR DESCRIPTION
완료

## 변경 사항
- 자정을 넘기는 근무를 고용주 캘린더 조회 범위에 맞게 시작일/종료일 양쪽에 표시하도록 수정했습니다.
- 캘린더 조회 시 전날 시작한 익일 근무도 함께 포함되도록 조회 범위를 보완했습니다.

## 테스트
- ./gradlew test --tests 'com.example.paycheck.domain.workrecord.service.WorkRecordQueryServiceTest'