### PR TITLE
[fix] 주간 캘린더 예상 근무비에 SCHEDULED 근무 포함

### DIFF
--- a/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordCommandService.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordCommandService.java
@@ -95,12 +95,12 @@ public class WorkRecordCommandService {
 
         WorkRecord savedRecord = workRecordRepository.save(workRecord);
 
-        // COMPLETED 상태면 정확한 휴일 정보와 사업장 규모를 반영하여 재계산
+        // 예상 급여 계산 (SCHEDULED, COMPLETED 모두 적용)
+        calculationService.calculateWorkRecordDetails(savedRecord);
         if (status == WorkRecordStatus.COMPLETED) {
-            calculationService.calculateWorkRecordDetails(savedRecord);
             calculationService.validateWorkRecordConsistency(savedRecord);
-            workRecordRepository.save(savedRecord);
         }
+        workRecordRepository.save(savedRecord);
 
         // 도메인 간 협력 처리
         if (status == WorkRecordStatus.COMPLETED) {
@@ -174,12 +174,12 @@ public class WorkRecordCommandService {
 
             workRecordRepository.save(workRecord);
 
-            // COMPLETED 상태면 정확한 휴일 정보와 사업장 규모를 반영하여 재계산
+            // 예상 급여 계산 (SCHEDULED, COMPLETED 모두 적용)
+            calculationService.calculateWorkRecordDetails(workRecord);
             if (workRecord.getStatus() == WorkRecordStatus.COMPLETED) {
-                calculationService.calculateWorkRecordDetails(workRecord);
                 calculationService.validateWorkRecordConsistency(workRecord);
-                workRecordRepository.save(workRecord);
             }
+            workRecordRepository.save(workRecord);
 
             // 도메인 간 협력 처리
             coordinatorService.handleWorkRecordUpdate(workRecord, oldWeeklyAllowance, newWeeklyAllowance);
@@ -349,20 +349,16 @@ public class WorkRecordCommandService {
         // 5. WorkRecord 일괄 저장 (saveAll 사용)
         List<WorkRecord> savedRecords = workRecordRepository.saveAll(workRecordsToSave);
 
-        // 6. COMPLETED 상태 WorkRecord 상세 일괄 계산
+        // 6. 전체 WorkRecord 예상 급여 일괄 계산 (SCHEDULED, COMPLETED 모두)
+        calculationService.calculateWorkRecordDetailsBatch(savedRecords);
+
         List<WorkRecord> completedRecords = savedRecords.stream()
                 .filter(wr -> wr.getStatus() == WorkRecordStatus.COMPLETED)
                 .collect(Collectors.toList());
-
-        calculationService.calculateWorkRecordDetailsBatch(completedRecords);
-        for (WorkRecord completedRecord : completedRecords) {
-            calculationService.validateWorkRecordConsistency(completedRecord);
-        }
+        completedRecords.forEach(calculationService::validateWorkRecordConsistency);
 
         // 7. 계산된 WorkRecord 일괄 업데이트
-        if (!completedRecords.isEmpty()) {
-            workRecordRepository.saveAll(completedRecords);
-        }
+        workRecordRepository.saveAll(savedRecords);
 
         // 8. 도메인 협력 처리 일괄 수행 (기존 handleBatchWorkRecordCreation 활용)
         coordinatorService.handleBatchWorkRecordCreation(savedRecords);

--- a/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordGenerationService.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/service/WorkRecordGenerationService.java
@@ -25,6 +25,7 @@ public class WorkRecordGenerationService {
 
     private final WorkRecordRepository workRecordRepository;
     private final ObjectMapper objectMapper;
+    private final WorkRecordCalculationService calculationService;
 
     /**
      * 계약 생성 시 2개월치 WorkRecord 생성
@@ -93,6 +94,7 @@ public class WorkRecordGenerationService {
         }
 
         if (!workRecords.isEmpty()) {
+            calculationService.calculateWorkRecordDetailsBatch(workRecords);
             workRecordRepository.saveAll(workRecords);
             log.info("WorkRecord 생성 완료: {} 개 생성됨 (Contract ID={})", workRecords.size(), contract.getId());
         }

--- a/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordCommandServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordCommandServiceTest.java
@@ -116,7 +116,7 @@ class WorkRecordCommandServiceTest {
 
         // then
         assertThat(result).isNotNull();
-        verify(workRecordRepository).save(any(WorkRecord.class));
+        verify(workRecordRepository, times(2)).save(any(WorkRecord.class));
     }
 
     @Test

--- a/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordGenerationServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/workrecord/service/WorkRecordGenerationServiceTest.java
@@ -32,6 +32,9 @@ class WorkRecordGenerationServiceTest {
     @Mock
     private WorkRecordRepository workRecordRepository;
 
+    @Mock
+    private WorkRecordCalculationService calculationService;
+
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
 


### PR DESCRIPTION
## 🔖 관련 GitHub Issue
- Closes #156

## 📝 변경 사항

### 주요 변경 내용
- SCHEDULED 상태의 근무 기록에도 예상 급여 계산 적용
- 주간 캘린더 API가 완료된 근무와 예정된 근무 모두의 급여를 반환

### 상세 설명

**문제**

`WorkRecordDto.DetailedResponse`의 `totalSalary` 필드가 SCHEDULED 상태 근무에서 항상 `0`으로 반환되어, 주간 캘린더의 '이번 주 예상 근무비' 계산 시 완료된 근무만 반영되는 버그.

**원인**

기존 코드는 `WorkRecordCommandService`와 `WorkRecordGenerationService`에서 `COMPLETED` 상태일 때만 `calculationService.calculateWorkRecordDetails()`를 호출하고, `SCHEDULED` 상태는 급여 계산을 건너뜀.

**수정 내용**

- `createWorkRecordByEmployer()`: `COMPLETED` 조건 제거, SCHEDULED 생성 시에도 예상 급여 계산
- `createWorkRecordsBatch()`: 전체 레코드에 예상 급여 일괄 계산 후 저장 (완료 레코드만 일괄 저장하던 버그도 함께 수정)
- `updateWorkRecord()`: `COMPLETED` 조건 제거, SCHEDULED 수정 시에도 예상 급여 재계산
- `WorkRecordGenerationService`: `WorkRecordCalculationService` 주입 추가, 자동 생성 레코드에도 예상 급여 계산 적용

SCHEDULED 근무가 COMPLETED로 전환되면 기존처럼 정확한 계산이 다시 수행됨.

## 📸 스크린샷 (선택사항)

<details>
<summary>스크린샷 보기</summary>

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

</details>

## ✅ 체크리스트
- [x] PR 제목이 형식에 맞는가? (유형: 작업 요약)
- [x] 코드가 정상적으로 빌드되는가?
- [x] 새로운 기능에 대한 테스트 코드를 작성했는가?
- [x] 모든 테스트가 통과하는가?
- [x] 코드 스타일 가이드를 따랐는가?
- [ ] 관련 문서를 업데이트했는가?

## 🔗 관련 PR
- Related to #

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 작업 기록 생성 및 업데이트 시 세부 정보 계산이 모든 상태에서 일관성 있게 적용되도록 개선

* **리팩토링**
  * 작업 기록 관련 데이터 처리 로직 정리 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->