### PR TITLE
[feat]: 탈퇴 유저 30일 후 영구 삭제 스케줄러 구현

### DIFF
--- a/src/main/java/com/example/paycheck/domain/allowance/repository/WeeklyAllowanceRepository.java
+++ b/src/main/java/com/example/paycheck/domain/allowance/repository/WeeklyAllowanceRepository.java
@@ -2,6 +2,7 @@ package com.example.paycheck.domain.allowance.repository;
 
 import com.example.paycheck.domain.allowance.entity.WeeklyAllowance;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -64,4 +65,11 @@ public interface WeeklyAllowanceRepository extends JpaRepository<WeeklyAllowance
             @Param("contractId") Long contractId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+    /**
+     * 영구 삭제용: 여러 계약의 모든 WeeklyAllowance 일괄 삭제
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM WeeklyAllowance wa WHERE wa.contract.id IN :contractIds")
+    void deleteAllByContractIdIn(@Param("contractIds") List<Long> contractIds);
 }

--- a/src/main/java/com/example/paycheck/domain/contract/repository/WorkerContractRepository.java
+++ b/src/main/java/com/example/paycheck/domain/contract/repository/WorkerContractRepository.java
@@ -62,4 +62,30 @@ public interface WorkerContractRepository extends JpaRepository<WorkerContract, 
             "JOIN FETCH c.workplace wp " +
             "WHERE c.isActive = true AND c.paymentDay >= :tomorrowDay")
     List<WorkerContract> findActiveContractsByPaymentDayOnLastDay(@Param("tomorrowDay") int tomorrowDay);
+
+    /**
+     * 영구 삭제용: 여러 사업장에 속한 모든 WorkerContract ID 조회
+     */
+    @Query("SELECT c.id FROM WorkerContract c WHERE c.workplace.id IN :workplaceIds")
+    List<Long> findIdsByWorkplaceIdIn(@Param("workplaceIds") List<Long> workplaceIds);
+
+    /**
+     * 영구 삭제용: 여러 사업장에 속한 모든 WorkerContract 일괄 삭제
+     */
+    @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true)
+    @Query("DELETE FROM WorkerContract c WHERE c.workplace.id IN :workplaceIds")
+    void deleteAllByWorkplaceIdIn(@Param("workplaceIds") List<Long> workplaceIds);
+
+    /**
+     * 영구 삭제용: 특정 근로자의 모든 WorkerContract ID 조회
+     */
+    @Query("SELECT c.id FROM WorkerContract c WHERE c.worker.id = :workerId")
+    List<Long> findIdsByWorkerId(@Param("workerId") Long workerId);
+
+    /**
+     * 영구 삭제용: 특정 근로자의 모든 WorkerContract 일괄 삭제
+     */
+    @org.springframework.data.jpa.repository.Modifying(clearAutomatically = true)
+    @Query("DELETE FROM WorkerContract c WHERE c.worker.id = :workerId")
+    void deleteAllByWorkerId(@Param("workerId") Long workerId);
 }

--- a/src/main/java/com/example/paycheck/domain/correction/repository/CorrectionRequestRepository.java
+++ b/src/main/java/com/example/paycheck/domain/correction/repository/CorrectionRequestRepository.java
@@ -149,4 +149,16 @@ public interface CorrectionRequestRepository extends JpaRepository<CorrectionReq
                         @Param("contractId") Long contractId,
                         @Param("date") LocalDate date,
                         @Param("status") WorkRecordStatus status);
+
+        // 영구 삭제용: 특정 사용자가 요청한 모든 정정요청 일괄 삭제
+        @Modifying(clearAutomatically = true)
+        @Query("DELETE FROM CorrectionRequest cr WHERE cr.requester.id = :userId")
+        void deleteAllByRequesterId(@Param("userId") Long userId);
+
+        // 영구 삭제용: 여러 계약(직접 참조 + WorkRecord 경유)에 연결된 정정요청 일괄 삭제
+        @Modifying(clearAutomatically = true)
+        @Query("DELETE FROM CorrectionRequest cr " +
+                        "WHERE cr.contract.id IN :contractIds " +
+                        "OR cr.workRecord.id IN (SELECT wr.id FROM WorkRecord wr WHERE wr.contract.id IN :contractIds)")
+        void deleteAllByContractIdIn(@Param("contractIds") List<Long> contractIds);
 }

--- a/src/main/java/com/example/paycheck/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/paycheck/domain/notice/repository/NoticeRepository.java
@@ -2,6 +2,7 @@ package com.example.paycheck.domain.notice.repository;
 
 import com.example.paycheck.domain.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -30,4 +31,18 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
            "WHERE n.id = :noticeId " +
            "AND n.isDeleted = false")
     Optional<Notice> findByIdAndIsDeletedFalse(@Param("noticeId") Long noticeId);
+
+    /**
+     * 영구 삭제용: 특정 작성자가 작성한 모든 공지 일괄 삭제
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notice n WHERE n.author.id = :userId")
+    void deleteAllByAuthorId(@Param("userId") Long userId);
+
+    /**
+     * 영구 삭제용: 여러 사업장에 속한 모든 공지 일괄 삭제
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notice n WHERE n.workplace.id IN :workplaceIds")
+    void deleteAllByWorkplaceIdIn(@Param("workplaceIds") List<Long> workplaceIds);
 }

--- a/src/main/java/com/example/paycheck/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/paycheck/domain/payment/repository/PaymentRepository.java
@@ -3,6 +3,7 @@ package com.example.paycheck.domain.payment.repository;
 import com.example.paycheck.domain.payment.entity.Payment;
 import com.example.paycheck.domain.payment.enums.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -98,4 +99,11 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
             @Param("userId") Long userId,
             @Param("year") Integer year,
             @Param("month") Integer month);
+
+    /**
+     * 영구 삭제용: 여러 Salary에 속한 Payment 일괄 삭제
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Payment p WHERE p.salary.id IN :salaryIds")
+    void deleteAllBySalaryIdIn(@Param("salaryIds") List<Long> salaryIds);
 }

--- a/src/main/java/com/example/paycheck/domain/salary/repository/SalaryRepository.java
+++ b/src/main/java/com/example/paycheck/domain/salary/repository/SalaryRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
@@ -81,4 +82,17 @@ public interface SalaryRepository extends JpaRepository<Salary, Long> {
             @Param("year") Integer year,
             @Param("month") Integer month
     );
+
+    /**
+     * 영구 삭제용: 여러 계약의 모든 Salary ID 조회 (Payment 선삭제용)
+     */
+    @Query("SELECT s.id FROM Salary s WHERE s.contract.id IN :contractIds")
+    List<Long> findIdsByContractIdIn(@Param("contractIds") List<Long> contractIds);
+
+    /**
+     * 영구 삭제용: 여러 계약의 모든 Salary 일괄 삭제
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Salary s WHERE s.contract.id IN :contractIds")
+    void deleteAllByContractIdIn(@Param("contractIds") List<Long> contractIds);
 }

--- a/src/main/java/com/example/paycheck/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/paycheck/domain/user/repository/UserRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(@Param("kakaoId") String kakaoId);
 
     boolean existsByKakaoId(String kakaoId);
+
+    @Query("SELECT u FROM User u WHERE u.deletedAt IS NOT NULL AND u.deletedAt < :threshold")
+    List<User> findAllByDeletedAtBefore(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/example/paycheck/domain/user/scheduler/UserHardDeleteScheduler.java
+++ b/src/main/java/com/example/paycheck/domain/user/scheduler/UserHardDeleteScheduler.java
@@ -1,0 +1,60 @@
+package com.example.paycheck.domain.user.scheduler;
+
+import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.user.repository.UserRepository;
+import com.example.paycheck.domain.user.service.UserHardDeleteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 탈퇴 후 30일이 경과한 사용자 데이터를 영구 삭제하는 스케줄러.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserHardDeleteScheduler {
+
+    private static final int RETENTION_DAYS = 30;
+
+    private final UserRepository userRepository;
+    private final UserHardDeleteService userHardDeleteService;
+
+    /**
+     * 매일 새벽 4시에 30일 경과 탈퇴 사용자 영구 삭제
+     * cron: 초 분 시 일 월 요일
+     * "0 0 4 * * *" = 매일 새벽 4시 정각
+     */
+    @Scheduled(cron = "0 0 4 * * *")
+    public void hardDeleteWithdrawnUsers() {
+        log.info("===== 탈퇴 사용자 영구 삭제 스케줄러 시작 =====");
+
+        LocalDateTime threshold = LocalDateTime.now().minusDays(RETENTION_DAYS);
+        List<User> targets = userRepository.findAllByDeletedAtBefore(threshold);
+
+        if (targets.isEmpty()) {
+            log.info("영구 삭제 대상 사용자가 없습니다.");
+            return;
+        }
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (User user : targets) {
+            try {
+                userHardDeleteService.hardDeleteUser(user.getId());
+                successCount++;
+            } catch (Exception e) {
+                log.error("사용자 영구 삭제 실패: userId={}, error={}", user.getId(), e.getMessage(), e);
+                failCount++;
+            }
+        }
+
+        log.info("===== 탈퇴 사용자 영구 삭제 스케줄러 완료 ===== (대상: {}, 성공: {}, 실패: {})",
+                targets.size(), successCount, failCount);
+    }
+}

--- a/src/main/java/com/example/paycheck/domain/user/service/UserHardDeleteService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserHardDeleteService.java
@@ -1,0 +1,170 @@
+package com.example.paycheck.domain.user.service;
+
+import com.example.paycheck.common.exception.ErrorCode;
+import com.example.paycheck.common.exception.NotFoundException;
+import com.example.paycheck.domain.allowance.repository.WeeklyAllowanceRepository;
+import com.example.paycheck.domain.auth.repository.RefreshTokenRepository;
+import com.example.paycheck.domain.contract.repository.WorkerContractRepository;
+import com.example.paycheck.domain.correction.repository.CorrectionRequestRepository;
+import com.example.paycheck.domain.employer.entity.Employer;
+import com.example.paycheck.domain.employer.repository.EmployerRepository;
+import com.example.paycheck.domain.fcm.repository.FcmTokenRepository;
+import com.example.paycheck.domain.notice.repository.NoticeRepository;
+import com.example.paycheck.domain.notification.repository.NotificationRepository;
+import com.example.paycheck.domain.payment.repository.PaymentRepository;
+import com.example.paycheck.domain.salary.repository.SalaryRepository;
+import com.example.paycheck.domain.settings.repository.UserSettingsRepository;
+import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.user.enums.UserType;
+import com.example.paycheck.domain.user.repository.UserRepository;
+import com.example.paycheck.domain.worker.entity.Worker;
+import com.example.paycheck.domain.worker.repository.WorkerRepository;
+import com.example.paycheck.domain.workplace.entity.Workplace;
+import com.example.paycheck.domain.workplace.repository.WorkplaceRepository;
+import com.example.paycheck.domain.workrecord.repository.WorkRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 탈퇴 30일 경과 사용자의 데이터를 영구 삭제하는 서비스.
+ * 트랜잭션은 사용자 1명 단위로 분리하여, 한 명의 실패가 다른 사용자에게 전파되지 않도록 한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserHardDeleteService {
+
+    private final UserRepository userRepository;
+    private final EmployerRepository employerRepository;
+    private final WorkerRepository workerRepository;
+    private final WorkplaceRepository workplaceRepository;
+    private final WorkerContractRepository workerContractRepository;
+    private final WorkRecordRepository workRecordRepository;
+    private final WeeklyAllowanceRepository weeklyAllowanceRepository;
+    private final SalaryRepository salaryRepository;
+    private final PaymentRepository paymentRepository;
+    private final CorrectionRequestRepository correctionRequestRepository;
+    private final NoticeRepository noticeRepository;
+    private final NotificationRepository notificationRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final UserSettingsRepository userSettingsRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 단일 사용자 영구 삭제.
+     * FK 제약을 고려한 순서로 연관 엔티티를 모두 hard delete 한다.
+     */
+    @Transactional
+    public void hardDeleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        if (user.getUserType() == UserType.EMPLOYER) {
+            hardDeleteEmployer(user);
+        } else {
+            hardDeleteWorker(user);
+        }
+
+        cleanupCommonData(user);
+        userRepository.delete(user);
+
+        log.info("사용자 영구 삭제 완료: userId={}, userType={}", user.getId(), user.getUserType());
+    }
+
+    /**
+     * 고용주 영구 삭제: 사업장 및 그 산하 모든 계약/근무/급여/결제/정정요청/공지를 정리한다.
+     */
+    private void hardDeleteEmployer(User user) {
+        Employer employer = employerRepository.findByUserId(user.getId()).orElse(null);
+        if (employer == null) {
+            return;
+        }
+
+        List<Workplace> workplaces = workplaceRepository.findByEmployerId(employer.getId());
+        List<Long> workplaceIds = workplaces.stream().map(Workplace::getId).toList();
+
+        List<Long> contractIds = workplaceIds.isEmpty()
+                ? List.of()
+                : workerContractRepository.findIdsByWorkplaceIdIn(workplaceIds);
+
+        deleteContractDescendants(user.getId(), contractIds);
+
+        if (!workplaceIds.isEmpty()) {
+            workerContractRepository.deleteAllByWorkplaceIdIn(workplaceIds);
+            noticeRepository.deleteAllByWorkplaceIdIn(workplaceIds);
+        }
+        // 사용자가 작성한 다른 사업장의 공지(가능성)도 정리
+        noticeRepository.deleteAllByAuthorId(user.getId());
+
+        if (!workplaceIds.isEmpty()) {
+            workplaceRepository.deleteAllByEmployerId(employer.getId());
+        }
+
+        employerRepository.delete(employer);
+    }
+
+    /**
+     * 근로자 영구 삭제: 본인의 모든 계약 및 그 산하 데이터를 정리한다.
+     * 다른 근로자나 고용주의 데이터에는 영향을 주지 않는다.
+     */
+    private void hardDeleteWorker(User user) {
+        Worker worker = workerRepository.findByUserId(user.getId()).orElse(null);
+        if (worker == null) {
+            return;
+        }
+
+        List<Long> contractIds = workerContractRepository.findIdsByWorkerId(worker.getId());
+
+        deleteContractDescendants(user.getId(), contractIds);
+
+        if (!contractIds.isEmpty()) {
+            workerContractRepository.deleteAllByWorkerId(worker.getId());
+        }
+        // 근로자가 작성한 공지(가능성)도 정리
+        noticeRepository.deleteAllByAuthorId(user.getId());
+
+        workerRepository.delete(worker);
+    }
+
+    /**
+     * 계약 산하 데이터를 FK 의존성 역순으로 삭제한다.
+     *  Payment → Salary → WorkRecord → WeeklyAllowance → CorrectionRequest
+     *  (CorrectionRequest는 WorkRecord/Contract를 참조하므로 가장 먼저 정리)
+     */
+    private void deleteContractDescendants(Long userId, List<Long> contractIds) {
+        // 사용자가 요청한 모든 정정요청 (다른 사업장에서의 요청 포함) 정리
+        correctionRequestRepository.deleteAllByRequesterId(userId);
+
+        if (contractIds.isEmpty()) {
+            return;
+        }
+
+        // 계약 직접 참조 + WorkRecord 경유 정정요청 정리
+        correctionRequestRepository.deleteAllByContractIdIn(contractIds);
+
+        // Payment는 Salary FK를 가지므로 먼저 삭제
+        List<Long> salaryIds = salaryRepository.findIdsByContractIdIn(contractIds);
+        if (!salaryIds.isEmpty()) {
+            paymentRepository.deleteAllBySalaryIdIn(salaryIds);
+        }
+        salaryRepository.deleteAllByContractIdIn(contractIds);
+
+        // WorkRecord는 weekly_allowance_id FK를 가지므로 WeeklyAllowance보다 먼저 삭제
+        workRecordRepository.deleteAllByContractIdIn(contractIds);
+        weeklyAllowanceRepository.deleteAllByContractIdIn(contractIds);
+    }
+
+    /**
+     * 사용자 단위 공통 부속 데이터 정리.
+     */
+    private void cleanupCommonData(User user) {
+        notificationRepository.deleteAllByUser(user);
+        fcmTokenRepository.deleteByUserId(user.getId());
+        userSettingsRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.deleteByUserId(user.getId());
+    }
+}

--- a/src/main/java/com/example/paycheck/domain/workplace/repository/WorkplaceRepository.java
+++ b/src/main/java/com/example/paycheck/domain/workplace/repository/WorkplaceRepository.java
@@ -2,6 +2,9 @@ package com.example.paycheck.domain.workplace.repository;
 
 import com.example.paycheck.domain.workplace.entity.Workplace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +13,11 @@ import java.util.List;
 public interface WorkplaceRepository extends JpaRepository<Workplace, Long> {
     List<Workplace> findByEmployerId(Long employerId);
     List<Workplace> findByEmployerIdAndIsActive(Long employerId, Boolean isActive);
+
+    /**
+     * 영구 삭제용: 특정 고용주의 모든 사업장 일괄 삭제
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Workplace w WHERE w.employer.id = :employerId")
+    void deleteAllByEmployerId(@Param("employerId") Long employerId);
 }

--- a/src/main/java/com/example/paycheck/domain/workrecord/repository/WorkRecordRepository.java
+++ b/src/main/java/com/example/paycheck/domain/workrecord/repository/WorkRecordRepository.java
@@ -159,6 +159,11 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
                         @Param("currentStatus") WorkRecordStatus currentStatus,
                         @Param("newStatus") WorkRecordStatus newStatus);
 
+        // 영구 삭제용: 여러 계약의 모든 WorkRecord 일괄 삭제
+        @Modifying(clearAutomatically = true)
+        @Query("DELETE FROM WorkRecord wr WHERE wr.contract.id IN :contractIds")
+        void deleteAllByContractIdIn(@Param("contractIds") List<Long> contractIds);
+
         // 현재 시점 기준으로 종료된 SCHEDULED 근무 기록 ID 조회 (자동 완료 배치용)
         // ID만 조회하여 메모리 효율 확보, 각 레코드는 completeWorkRecord(Long)에서 개별 트랜잭션으로 처리
         @Query("SELECT wr.id FROM WorkRecord wr " +

--- a/src/test/java/com/example/paycheck/domain/user/service/UserHardDeleteServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserHardDeleteServiceTest.java
@@ -1,0 +1,227 @@
+package com.example.paycheck.domain.user.service;
+
+import com.example.paycheck.common.exception.NotFoundException;
+import com.example.paycheck.domain.allowance.repository.WeeklyAllowanceRepository;
+import com.example.paycheck.domain.auth.repository.RefreshTokenRepository;
+import com.example.paycheck.domain.contract.repository.WorkerContractRepository;
+import com.example.paycheck.domain.correction.repository.CorrectionRequestRepository;
+import com.example.paycheck.domain.employer.entity.Employer;
+import com.example.paycheck.domain.employer.repository.EmployerRepository;
+import com.example.paycheck.domain.fcm.repository.FcmTokenRepository;
+import com.example.paycheck.domain.notice.repository.NoticeRepository;
+import com.example.paycheck.domain.notification.repository.NotificationRepository;
+import com.example.paycheck.domain.payment.repository.PaymentRepository;
+import com.example.paycheck.domain.salary.repository.SalaryRepository;
+import com.example.paycheck.domain.settings.repository.UserSettingsRepository;
+import com.example.paycheck.domain.user.entity.User;
+import com.example.paycheck.domain.user.enums.UserType;
+import com.example.paycheck.domain.user.repository.UserRepository;
+import com.example.paycheck.domain.worker.entity.Worker;
+import com.example.paycheck.domain.worker.repository.WorkerRepository;
+import com.example.paycheck.domain.workplace.entity.Workplace;
+import com.example.paycheck.domain.workplace.repository.WorkplaceRepository;
+import com.example.paycheck.domain.workrecord.repository.WorkRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserHardDeleteService 테스트")
+class UserHardDeleteServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private EmployerRepository employerRepository;
+    @Mock private WorkerRepository workerRepository;
+    @Mock private WorkplaceRepository workplaceRepository;
+    @Mock private WorkerContractRepository workerContractRepository;
+    @Mock private WorkRecordRepository workRecordRepository;
+    @Mock private WeeklyAllowanceRepository weeklyAllowanceRepository;
+    @Mock private SalaryRepository salaryRepository;
+    @Mock private PaymentRepository paymentRepository;
+    @Mock private CorrectionRequestRepository correctionRequestRepository;
+    @Mock private NoticeRepository noticeRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private FcmTokenRepository fcmTokenRepository;
+    @Mock private UserSettingsRepository userSettingsRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private UserHardDeleteService userHardDeleteService;
+
+    private User employerUser;
+    private User workerUser;
+
+    @BeforeEach
+    void setUp() {
+        employerUser = User.builder()
+                .id(1L)
+                .kakaoId("kakao_employer")
+                .name("고용주")
+                .userType(UserType.EMPLOYER)
+                .build();
+        employerUser.withdraw();
+
+        workerUser = User.builder()
+                .id(2L)
+                .kakaoId("kakao_worker")
+                .name("근로자")
+                .userType(UserType.WORKER)
+                .build();
+        workerUser.withdraw();
+    }
+
+    @Test
+    @DisplayName("고용주 영구 삭제 - 사업장/계약/하위 모든 데이터 삭제 + FK 순서 보장")
+    void hardDeleteEmployer_success() {
+        // given
+        Employer employer = Employer.builder().id(10L).user(employerUser).phone("010-1111-2222").build();
+        Workplace workplace = Workplace.builder().id(100L).employer(employer).name("사업장A").build();
+
+        when(userRepository.findById(employerUser.getId())).thenReturn(Optional.of(employerUser));
+        when(employerRepository.findByUserId(employerUser.getId())).thenReturn(Optional.of(employer));
+        when(workplaceRepository.findByEmployerId(employer.getId())).thenReturn(List.of(workplace));
+        when(workerContractRepository.findIdsByWorkplaceIdIn(List.of(100L))).thenReturn(List.of(1000L, 1001L));
+        when(salaryRepository.findIdsByContractIdIn(List.of(1000L, 1001L))).thenReturn(List.of(5000L));
+
+        // when
+        userHardDeleteService.hardDeleteUser(employerUser.getId());
+
+        // then - FK 순서 검증
+        InOrder inOrder = inOrder(
+                correctionRequestRepository, paymentRepository, salaryRepository,
+                workRecordRepository, weeklyAllowanceRepository, workerContractRepository,
+                noticeRepository, workplaceRepository, employerRepository, userRepository);
+
+        inOrder.verify(correctionRequestRepository).deleteAllByRequesterId(employerUser.getId());
+        inOrder.verify(correctionRequestRepository).deleteAllByContractIdIn(List.of(1000L, 1001L));
+        inOrder.verify(paymentRepository).deleteAllBySalaryIdIn(List.of(5000L));
+        inOrder.verify(salaryRepository).deleteAllByContractIdIn(List.of(1000L, 1001L));
+        inOrder.verify(workRecordRepository).deleteAllByContractIdIn(List.of(1000L, 1001L));
+        inOrder.verify(weeklyAllowanceRepository).deleteAllByContractIdIn(List.of(1000L, 1001L));
+        inOrder.verify(workerContractRepository).deleteAllByWorkplaceIdIn(List.of(100L));
+        inOrder.verify(noticeRepository).deleteAllByWorkplaceIdIn(List.of(100L));
+        inOrder.verify(noticeRepository).deleteAllByAuthorId(employerUser.getId());
+        inOrder.verify(workplaceRepository).deleteAllByEmployerId(employer.getId());
+        inOrder.verify(employerRepository).delete(employer);
+        inOrder.verify(userRepository).delete(employerUser);
+    }
+
+    @Test
+    @DisplayName("근로자 영구 삭제 - 본인 계약/하위 데이터만 삭제")
+    void hardDeleteWorker_success() {
+        // given
+        Worker worker = Worker.builder().id(20L).user(workerUser).workerCode("ABC123").build();
+
+        when(userRepository.findById(workerUser.getId())).thenReturn(Optional.of(workerUser));
+        when(workerRepository.findByUserId(workerUser.getId())).thenReturn(Optional.of(worker));
+        when(workerContractRepository.findIdsByWorkerId(worker.getId())).thenReturn(List.of(2000L));
+        when(salaryRepository.findIdsByContractIdIn(List.of(2000L))).thenReturn(List.of());
+
+        // when
+        userHardDeleteService.hardDeleteUser(workerUser.getId());
+
+        // then
+        InOrder inOrder = inOrder(
+                correctionRequestRepository, salaryRepository, workRecordRepository,
+                weeklyAllowanceRepository, workerContractRepository, noticeRepository,
+                workerRepository, userRepository);
+
+        inOrder.verify(correctionRequestRepository).deleteAllByRequesterId(workerUser.getId());
+        inOrder.verify(correctionRequestRepository).deleteAllByContractIdIn(List.of(2000L));
+        inOrder.verify(salaryRepository).deleteAllByContractIdIn(List.of(2000L));
+        inOrder.verify(workRecordRepository).deleteAllByContractIdIn(List.of(2000L));
+        inOrder.verify(weeklyAllowanceRepository).deleteAllByContractIdIn(List.of(2000L));
+        inOrder.verify(workerContractRepository).deleteAllByWorkerId(worker.getId());
+        inOrder.verify(noticeRepository).deleteAllByAuthorId(workerUser.getId());
+        inOrder.verify(workerRepository).delete(worker);
+        inOrder.verify(userRepository).delete(workerUser);
+
+        // salary IDs가 비어있으므로 Payment 삭제는 호출되지 않음
+        verify(paymentRepository, never()).deleteAllBySalaryIdIn(any());
+    }
+
+    @Test
+    @DisplayName("공통 데이터 정리 - Notification, FcmToken, UserSettings, RefreshToken 삭제")
+    void hardDeleteUser_cleanupsCommonData() {
+        // given
+        when(userRepository.findById(workerUser.getId())).thenReturn(Optional.of(workerUser));
+        when(workerRepository.findByUserId(workerUser.getId())).thenReturn(Optional.empty());
+
+        // when
+        userHardDeleteService.hardDeleteUser(workerUser.getId());
+
+        // then
+        verify(notificationRepository).deleteAllByUser(workerUser);
+        verify(fcmTokenRepository).deleteByUserId(workerUser.getId());
+        verify(userSettingsRepository).deleteByUserId(workerUser.getId());
+        verify(refreshTokenRepository).deleteByUserId(workerUser.getId());
+        verify(userRepository).delete(workerUser);
+    }
+
+    @Test
+    @DisplayName("Employer 프로필이 없어도 NPE 없이 정상 정리")
+    void hardDeleteEmployer_noProfile_noException() {
+        // given
+        when(userRepository.findById(employerUser.getId())).thenReturn(Optional.of(employerUser));
+        when(employerRepository.findByUserId(employerUser.getId())).thenReturn(Optional.empty());
+
+        // when
+        userHardDeleteService.hardDeleteUser(employerUser.getId());
+
+        // then
+        verify(workplaceRepository, never()).findByEmployerId(any());
+        verify(workerContractRepository, never()).findIdsByWorkplaceIdIn(any());
+        verify(userRepository).delete(employerUser);
+    }
+
+    @Test
+    @DisplayName("계약/사업장이 없는 고용주는 빈 IN절 쿼리를 호출하지 않음")
+    void hardDeleteEmployer_noWorkplaces_skipsBulkQueries() {
+        // given
+        Employer employer = Employer.builder().id(10L).user(employerUser).build();
+        when(userRepository.findById(employerUser.getId())).thenReturn(Optional.of(employerUser));
+        when(employerRepository.findByUserId(employerUser.getId())).thenReturn(Optional.of(employer));
+        when(workplaceRepository.findByEmployerId(employer.getId())).thenReturn(List.of());
+
+        // when
+        userHardDeleteService.hardDeleteUser(employerUser.getId());
+
+        // then - 빈 workplaceIds는 in절 쿼리 미호출
+        verify(workerContractRepository, never()).findIdsByWorkplaceIdIn(any());
+        verify(workerContractRepository, never()).deleteAllByWorkplaceIdIn(any());
+        verify(noticeRepository, never()).deleteAllByWorkplaceIdIn(any());
+        verify(workplaceRepository, never()).deleteAllByEmployerId(any());
+        // 본인 작성 공지는 여전히 정리
+        verify(noticeRepository).deleteAllByAuthorId(employerUser.getId());
+        // requester 정정요청은 항상 정리
+        verify(correctionRequestRepository).deleteAllByRequesterId(employerUser.getId());
+        // contract IDs 비어있으므로 contract 기반 정정요청 삭제는 미호출
+        verify(correctionRequestRepository, never()).deleteAllByContractIdIn(any());
+        verify(employerRepository).delete(employer);
+        verify(userRepository).delete(employerUser);
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 NotFoundException")
+    void hardDeleteUser_notFound_throwsException() {
+        // given
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userHardDeleteService.hardDeleteUser(99L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("사용자를 찾을 수 없습니다");
+    }
+}


### PR DESCRIPTION
## 요약
- 탈퇴 후 30일이 경과한 사용자의 데이터를 FK 제약을 고려한 순서로 hard delete 처리
- 매일 새벽 4시에 자동 실행되는 스케줄러 추가
- 고용주/근로자 케이스별 삭제 로직 분리, 다른 사용자 데이터 영향 방지

Closes #131 

## 구현 상세

### UserHardDeleteService
- 사용자 1명 단위 트랜잭션으로 한 명 실패가 다른 사용자에 영향 없음
- **고용주 탈퇴**: 사업장 → WorkerContract → 하위 모든 데이터(WorkRecord, WeeklyAllowance, Salary, Payment) → CorrectionRequest → Notice → Workplace → Employer 정리
- **근로자 탈퇴**: 본인의 WorkerContract만 정리 (다른 근로자 데이터 영향 없음)
- FK 삭제 순서: CorrectionRequest → Payment → Salary → WorkRecord → WeeklyAllowance → WorkerContract → Notice → Workplace → Employer/Worker → User

### UserHardDeleteScheduler  
- `@Scheduled(cron = "0 0 4 * * *")` — 매일 새벽 4시
- 30일 임계값: `LocalDateTime.now().minusDays(30)`
- 유저별 try-catch로 격리, 실패 로깅

### Repository 메서드 추가
신규 bulk delete 메서드 (총 12개):
- `@Modifying(clearAutomatically = true)` 사용으로 영속성 컨텍스트 stale 방지
- 빈 리스트 처리: 호출 전 isEmpty() 체크

## 테스트 전략

### UserHardDeleteServiceTest (6개 시나리오)
- ✅ 고용주 영구 삭제: FK 순서 검증 (InOrder 사용)
- ✅ 근로자 영구 삭제: 본인 계약만 정리 확인
- ✅ 공통 데이터 정리: Notification, FcmToken, UserSettings, RefreshToken
- ✅ Employer/Worker 프로필 없는 케이스: NPE 안전성
- ✅ 계약/사업장 없는 경우: 빈 IN절 쿼리 미호출
- ✅ NotFoundException: 사용자 존재 검증

### 테스트 실행 결과
```bash
./gradlew test --tests UserHardDeleteServiceTest
./gradlew test --tests UserWithdrawServiceTest
./gradlew clean build
→ BUILD SUCCESSFUL
```

## 선행 조건
이슈 #130 (detached 엔티티로 인한 deletedAt 미반영 버그) 완료

## 참고사항
- Scheduler 실행 시간: 새벽 4시 (기존 스케줄러와 시간 분산: RefreshToken=3시, WorkRecord=2시)
- 근로자 삭제 시 영향 분리: 근로자의 contract ID만으로 조회/삭제하므로, 같은 사업장의 다른 근로자 데이터 안전
- 고용주 삭제 시: 사업장 산하 모든 근로자의 계약이 정리되지만, 근로자 엔티티 자체는 삭제 안 됨 (다른 사업장에서의 활동 보존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원 탈퇴 후 30일 이후 계정이 자동으로 삭제되는 기능이 추가되었습니다. 매일 오전 4시에 자동 삭제 프로세스가 실행되며, 삭제된 계정과 관련된 모든 데이터는 영구적으로 제거됩니다.

* **테스트**
  * 사용자 계정 삭제 기능에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->