### PR TITLE
[fix] users 테이블 version 컬럼 추가

### DIFF
--- a/src/main/resources/db/migration/V20260505__Add_version_column_to_users.sql
+++ b/src/main/resources/db/migration/V20260505__Add_version_column_to_users.sql
@@ -1,0 +1,2 @@
+-- Issue #181: users 테이블에 version 컬럼 추가 (JPA Optimistic Locking)
+ALTER TABLE users ADD COLUMN version BIGINT DEFAULT 0;

--- a/src/main/resources/db/migration/V20260505__Add_version_column_to_users.sql
+++ b/src/main/resources/db/migration/V20260505__Add_version_column_to_users.sql
@@ -1,2 +1,2 @@
 -- Issue #181: users 테이블에 version 컬럼 추가 (JPA Optimistic Locking)
-ALTER TABLE users ADD COLUMN version BIGINT DEFAULT 0;
+ALTER TABLE users ADD COLUMN version BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## 🔖 관련 GitHub Issue
- Closes #181

## 📝 변경 사항

### 주요 변경 내용
- `users` 테이블에 `version BIGINT DEFAULT 0` 컬럼을 추가하는 Flyway 마이그레이션 파일 생성
  - 파일: `V20260505__Add_version_column_to_users.sql`

### 상세 설명
`User` 엔티티에 JPA Optimistic Locking을 위한 `@Version` 어노테이션이 추가되었으나, 대응되는 DB 마이그레이션 파일이 누락되어 있었습니다. 이로 인해 운영 서버의 `users` 테이블에 `version` 컬럼이 없어 다음과 같은 오류가 발생했습니다.

```
Caused by: java.sql.SQLSyntaxErrorException: Unknown column 'u1_0.version' in 'field list'
```

영향 범위는 `users` 테이블을 조회하는 모든 엔드포인트(로그인 포함)였으며, 사실상 모든 API 요청이 500 Internal Server Error를 반환하는 상태였습니다.

**해결 방법**
- `BIGINT` 타입으로 컬럼 추가 (Java `Long` 타입과 매핑)
- `DEFAULT 0`으로 설정하여 기존 사용자 row의 version 값을 0으로 초기화 (JPA `@Version` 표준 시작 값)
- Flyway가 애플리케이션 시작 시 자동으로 마이그레이션을 적용

## ✅ 체크리스트
- [x] PR 제목이 형식에 맞는가? (유형: 작업 요약)
- [x] 코드가 정상적으로 빌드되는가?
- [x] 새로운 기능에 대한 테스트 코드를 작성했는가? (DB 스키마 마이그레이션이라 해당 없음)
- [x] 모든 테스트가 통과하는가?
- [x] 코드 스타일 가이드를 따랐는가?
- [x] 관련 문서를 업데이트했는가? (해당 없음)

## 🔗 관련 PR
- Related to #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 동시성 업데이트 처리 개선을 위한 데이터베이스 스키마 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->