### PR TITLE
[fix] 회원 복구 시 비활성화된 사업장 재활성화

### DIFF
--- a/src/main/java/com/example/paycheck/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/paycheck/domain/auth/service/AuthService.java
@@ -139,8 +139,9 @@ public class AuthService {
     /**
      * 탈퇴한 카카오 계정 복구 (탈퇴 취소)
      * - User.deletedAt = null로 되돌림
+     * - 고용주의 경우 탈퇴 시 비활성화된 사업장을 함께 복원 (사업자번호 재등록 가능)
      * - UserSettings는 탈퇴 시 보존되었으므로 그대로 사용 (이전 알림 설정 유지)
-     * - 사업장/계약/근무기록은 자동 복구하지 않음 (다른 사용자 데이터 일관성 보호)
+     * - 계약/근무기록은 자동 복구하지 않음 (다른 사용자 데이터 일관성 보호)
      *
      * @param kakaoAccessToken 카카오 액세스 토큰
      * @return 로그인 응답 (refreshToken 포함)
@@ -164,6 +165,7 @@ public class AuthService {
         assertWithinRecoveryPeriod(user);
 
         user.restore();
+        userWithdrawService.restoreEmployerWorkplaces(user);
 
         return buildLoginResponse(user);
     }

--- a/src/main/java/com/example/paycheck/domain/user/service/UserWithdrawService.java
+++ b/src/main/java/com/example/paycheck/domain/user/service/UserWithdrawService.java
@@ -140,6 +140,23 @@ public class UserWithdrawService {
     }
 
     /**
+     * 고용주 계정 복구 시 탈퇴 과정에서 비활성화된 사업장 재활성화
+     * Worker 타입이거나 Employer 프로필이 없으면 아무것도 하지 않는다.
+     */
+    public void restoreEmployerWorkplaces(User user) {
+        if (user.getUserType() != UserType.EMPLOYER) {
+            return;
+        }
+        Employer employer = employerRepository.findByUserId(user.getId()).orElse(null);
+        if (employer == null) {
+            return;
+        }
+        List<Workplace> deactivatedWorkplaces =
+                workplaceRepository.findByEmployerIdAndIsActive(employer.getId(), false);
+        deactivatedWorkplaces.forEach(Workplace::activate);
+    }
+
+    /**
      * 공통 데이터 정리
      * UserSettings는 30일 이내 복구 시 사용자가 이전에 설정한 알림 옵션을 그대로 살리기 위해
      * 탈퇴 시점에는 보존하며, 30일 후 hard delete 시 UserHardDeleteService에서 함께 정리된다.

--- a/src/test/java/com/example/paycheck/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/auth/service/AuthServiceTest.java
@@ -573,6 +573,30 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("탈퇴 계정 복구 성공 - EMPLOYER 타입은 사업장 재활성화 호출")
+    void restoreWithKakao_Employer_ActivatesWorkplaces() {
+        // given
+        String kakaoAccessToken = "kakao_access_token";
+        User deletedEmployer = User.builder()
+                .id(3L)
+                .kakaoId("test_kakao_id")
+                .name("탈퇴한 고용주")
+                .userType(UserType.EMPLOYER)
+                .build();
+        deletedEmployer.withdraw();
+
+        when(oAuthService.getKakaoUserInfo(kakaoAccessToken)).thenReturn(kakaoUserInfo);
+        when(userRepository.findByKakaoId(kakaoUserInfo.kakaoId())).thenReturn(Optional.of(deletedEmployer));
+        when(tokenService.generateTokenPair(deletedEmployer.getId())).thenReturn(tokenPair);
+
+        // when
+        authService.restoreWithKakao(kakaoAccessToken);
+
+        // then
+        verify(userWithdrawService).restoreEmployerWorkplaces(deletedEmployer);
+    }
+
+    @Test
     @DisplayName("탈퇴 계정 복구 실패 - 정상 계정에 호출 시 USER_NOT_WITHDRAWN 예외")
     void restoreWithKakao_NotWithdrawn_ThrowsException() {
         // given

--- a/src/test/java/com/example/paycheck/domain/user/service/UserWithdrawServiceTest.java
+++ b/src/test/java/com/example/paycheck/domain/user/service/UserWithdrawServiceTest.java
@@ -261,6 +261,46 @@ class UserWithdrawServiceTest {
     }
 
     @Test
+    @DisplayName("고용주 복구 시 비활성화된 사업장 재활성화")
+    void restoreEmployerWorkplaces_success() {
+        // given
+        Employer employerEntity = Employer.builder()
+                .id(10L)
+                .user(employer)
+                .phone("010-1234-5678")
+                .build();
+
+        Workplace deactivatedWorkplace = Workplace.builder()
+                .id(100L)
+                .employer(employerEntity)
+                .name("테스트 사업장")
+                .businessNumber("166-12-01262")
+                .isActive(false)
+                .build();
+
+        when(employerRepository.findByUserId(employer.getId())).thenReturn(Optional.of(employerEntity));
+        when(workplaceRepository.findByEmployerIdAndIsActive(employerEntity.getId(), false))
+                .thenReturn(List.of(deactivatedWorkplace));
+
+        // when
+        userWithdrawService.restoreEmployerWorkplaces(employer);
+
+        // then
+        assertThat(deactivatedWorkplace.getIsActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("WORKER 타입 사용자 복구 시 repository 접근 없이 즉시 return")
+    void restoreEmployerWorkplaces_workerUser_doesNothing() {
+        // when
+        userWithdrawService.restoreEmployerWorkplaces(worker);
+
+        // then
+        verify(employerRepository, never()).findByUserId(any());
+        verify(workplaceRepository, never()).findByEmployerIdAndIsActive(any(), any());
+    }
+
+    @Test
     @DisplayName("findById 결과가 비어있을 때 NotFoundException 발생")
     void withdraw_userNotFound_throwsNotFoundException() {
         // given


### PR DESCRIPTION
## 🔖 관련 GitHub Issue
- Closes #187

## 📝 변경 사항

### 주요 변경 내용
- `UserWithdrawService`에 `restoreEmployerWorkplaces()` 메서드 추가
- `AuthService.restoreWithKakao()`에서 `user.restore()` 직후 사업장 재활성화 호출
- 관련 단위 테스트 추가 (`AuthServiceTest`, `UserWithdrawServiceTest`)

### 상세 설명
**버그 원인**

탈퇴 시 `withdrawEmployer()`가 고용주의 모든 `Workplace`를 `isActive=false`로 비활성화하지만, 복구 시 `restoreWithKakao()`는 `User.deletedAt = null`만 되돌리고 사업장을 재활성화하지 않았습니다.

그 결과 복구 후 사업장 목록은 비어있는 것처럼 보이지만, DB에는 `isActive=false`인 row가 남아있어 동일 `business_number`로 사업장을 재등록하려 하면 UNIQUE 제약 위반이 발생했습니다.

**수정 방법**

`UserWithdrawService.restoreEmployerWorkplaces(User user)`를 추가하여 EMPLOYER 타입 복구 시 `workplaceRepository.findByEmployerIdAndIsActive(employerId, false)`로 비활성 사업장을 조회해 일괄 `activate()`합니다.

- 계약·근무기록은 기존과 동일하게 복구하지 않습니다 (다른 근로자 데이터 일관성 보호)
- `Workplace.activate()` 메서드 및 `findByEmployerIdAndIsActive()` 쿼리는 기존 코드 재사용

## 📸 스크린샷 (선택사항)

백엔드 버그 수정으로 해당 없음

## ✅ 체크리스트
- [x] PR 제목이 형식에 맞는가? (유형: 작업 요약)
- [x] 코드가 정상적으로 빌드되는가?
- [x] 새로운 기능에 대한 테스트 코드를 작성했는가?
- [x] 모든 테스트가 통과하는가?
- [x] 코드 스타일 가이드를 따랐는가?
- [ ] 관련 문서를 업데이트했는가?

## 🔗 관련 PR
- Related to #184
- Related to #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카카오 탈퇴 계정 복구 시 고용주 사용자의 비활성화된 직장(사업장)이 자동으로 재활성화됩니다. 비즈니스 번호 재등록도 함께 진행됩니다.
  * 사용자 설정은 복구 중에도 유지됩니다.

* **테스트**
  * 고용주 계정 복구 시나리오에 대한 테스트 커버리지를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-PayCheck/PayCheck-backend/pull/188)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->