### PR TITLE
[fix] prod 프로파일에서 lazy-initialization 제거로 SecurityFilterChain 미등록 문제 해결

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,9 +26,11 @@ aws.s3.secret-key=${AWS_S3_SECRET_KEY:}
 spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=none
 
-# Lazy Initialization: 시작 시 모든 빈을 한 번에 초기화하지 않고 요청 시 초기화
-# Hibernate 6 ANTLR4 파서의 시작 시 메모리 스파이크 방지
-spring.main.lazy-initialization=true
+# spring.main.lazy-initialization 제거 (#189)
+# Spring Security의 SecurityFilterChain 자동 구성이 lazy 초기화 상태에서
+# 사용자 정의 SecurityFilterChain 빈을 감지하지 못해 폴백 보안(inMemoryUserDetailsManager)이
+# 활성화되는 문제가 발생했다. 메모리 스파이크가 다시 문제될 경우 lazy-init이 아닌
+# Hibernate plan cache 한도 / Tomcat 스레드 한도 / OSIV 비활성화 등으로 대응한다.
 
 # Database Configuration - AWS RDS MySQL
 # 반드시 환경변수로 주입: DB_HOST, DB_USERNAME, DB_PASSWORD


### PR DESCRIPTION
## 🔖 관련 GitHub Issue
- Closes #189

## 📝 변경 사항

### 주요 변경 내용
- `application-prod.properties`에서 `spring.main.lazy-initialization=true` 설정 제거
- 동일 위치에 사유와 후속 대응 가이드를 주석으로 남김

### 상세 설명

#### 문제

2026-05-14 09:32 KST 프로덕션 EC2 재배포 이후, 모바일 앱의 카카오 로그인 및 Dev 로그인이 모두 실패. EC2에서 직접 `curl`로 호출해도 모든 `/api/auth/*` 엔드포인트가 빈 본문 403을 반환. 부팅 로그에 결정적 신호가 출력됨:

```
WARN  UserDetailsServiceAutoConfiguration : Using generated security password: ...
INFO  InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with UserDetailsService bean with name inMemoryUserDetailsManager
```

→ Spring Boot가 우리 `SecurityFilterChain` 빈을 감지하지 못하고 폴백 보안(HTTP Basic + `inMemoryUserDetailsManager` + CSRF on)을 활성화한 상태. 결과적으로 `SecurityConfig`의 `permitAll()` 설정이 무시되어 모든 POST 요청이 403.

#### 원인

`application-prod.properties`에 prod 전용으로 설정되어 있던:

```properties
spring.main.lazy-initialization=true
```

이 설정 때문에 사용자 정의 `SecurityFilterChain` 빈이 lazy 초기화 상태로 등록되며, Spring Boot의 `SpringBootWebSecurityConfiguration`이 `@ConditionalOnDefaultWebSecurity`(= `@ConditionalOnMissingBean(SecurityFilterChain.class)`) 평가 시점에 사용자 정의 빈의 존재를 감지하지 못해 폴백 보안 체인을 활성화함.

해당 설정은 `application.properties`/`application-local.properties`에는 없고 **prod에만 존재**했기 때문에 로컬에서는 정상 동작하고 프로덕션에서만 재현되었음.

#### 해결

prod 프로파일에서 `spring.main.lazy-initialization=true` 설정을 제거. `SecurityConfig.java` 등 코드는 변경하지 않음(코드 자체는 정상).

원래 lazy-init을 도입한 의도(시작 시 Hibernate 6 ANTLR4 파서 메모리 스파이크 방지)는 별도 옵션으로 대응할 수 있도록 주석에 안내를 남김:
- Hibernate plan cache 한도 (`hibernate.query.plan_cache_max_size`, `plan_parameter_metadata_max_size`)
- Tomcat 스레드 한도 (`server.tomcat.threads.max`, `accept-count`)
- OSIV 비활성화 (`spring.jpa.open-in-view=false`)

배포 후 EC2 staging에서 실제 메모리 스파이크가 관측되면 위 옵션들로 별도 PR 대응 예정.

## ✅ 체크리스트
- [x] PR 제목이 형식에 맞는가? (유형: 작업 요약)
- [x] 코드가 정상적으로 빌드되는가? (`./gradlew test --tests PayCheckApplicationTests` BUILD SUCCESSFUL)
- [ ] 새로운 기능에 대한 테스트 코드를 작성했는가? (해당 없음 - 설정 파일 변경)
- [x] 모든 테스트가 통과하는가?
- [x] 코드 스타일 가이드를 따랐는가?
- [ ] 관련 문서를 업데이트했는가? (해당 없음)

## 🔗 관련 PR
- Related to #186 (직전 SecurityConfig permitAll 경로 수정 PR)

## 🧪 검증

### 자동 검증
```
./gradlew test --tests PayCheckApplicationTests
→ BUILD SUCCESSFUL
```

### 배포 후 수동 검증
1. **폴백 로그 부재 확인**
   ```bash
   sudo journalctl -u paycheck --since '<배포시각>' \
     | grep -E 'generated security password|inMemoryUserDetailsManager'
   # → 아무것도 출력되지 않아야 함
   ```

2. **로그인 동작 재현**
   ```bash
   curl -i -X POST http://localhost:8080/api/auth/kakao/login \
     -H 'Content-Type: application/json' \
     -d '{"kakaoAccessToken":"..."}'
   # → 403이 아닌 정상 응답 또는 의도된 비즈니스 에러
   ```

3. **인증 보호 경로**
   ```bash
   curl -i http://localhost:8080/api/users/me
   # → 401 + ApiResponse.error JSON (403 아님, JwtAuthenticationFilter 응답)
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* Spring Security의 보안 필터가 올바르게 작동하도록 애플리케이션 초기화 방식이 조정되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-PayCheck/PayCheck-backend/pull/190)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->